### PR TITLE
Refactor bubble animations to use shared base

### DIFF
--- a/bubbler-common-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/display/DisplayMetadataPacket.java
+++ b/bubbler-common-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/display/DisplayMetadataPacket.java
@@ -1,0 +1,52 @@
+package me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display;
+
+import com.github.retrooper.packetevents.protocol.entity.data.EntityData;
+import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes;
+import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.util.Vector3f;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+import me.whereareiam.socialismus.api.type.Version;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.ProtocolVersion;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.Packet;
+import me.whereareiam.socialismus.module.bubbler.api.type.DisplayType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Packet used to update display entity metadata, such as scale or translation.
+ */
+@Getter
+@SuperBuilder
+public class DisplayMetadataPacket implements Packet {
+    private final int entityId;
+    private final Vector3f translation;
+    private final Vector3f scale;
+    private final DisplayType type;
+
+    @Override
+    public void send(User user) {
+        WrapperPlayServerEntityMetadata packet = createMetadataPacket();
+        user.sendPacket(packet);
+    }
+
+    private WrapperPlayServerEntityMetadata createMetadataPacket() {
+        List<EntityData> metadata = new ArrayList<>();
+
+        if (ProtocolVersion.VERSION.isAtLeast(Version.V_1_21_4)) {
+            if (translation != null) {
+                metadata.add(new EntityData(11, EntityDataTypes.VECTOR3F, translation));
+            }
+            if (scale != null) {
+                metadata.add(new EntityData(12, EntityDataTypes.VECTOR3F, scale));
+            }
+            if (type != null) {
+                metadata.add(new EntityData(15, EntityDataTypes.BYTE, type.getValue()));
+            }
+        }
+
+        return new WrapperPlayServerEntityMetadata(entityId, metadata);
+    }
+}

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/BubbleAnimationFactory.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/BubbleAnimationFactory.java
@@ -7,17 +7,19 @@ import lombok.RequiredArgsConstructor;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleAnimation;
 import me.whereareiam.socialismus.module.bubbler.api.type.AnimationType;
 import me.whereareiam.socialismus.module.bubbler.common.animation.mode.StaticBubbleAnimation;
+import me.whereareiam.socialismus.module.bubbler.common.animation.mode.ExpansionBubbleAnimation;
+import me.whereareiam.socialismus.module.bubbler.common.animation.mode.PopoutBubbleAnimation;
 
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = {@Inject})
 public class BubbleAnimationFactory {
 	private final Injector injector;
 
-	public BubbleAnimation getAnimation(AnimationType animationType) {
-		return switch (animationType) {
-			case EXPANSION -> throw new UnsupportedOperationException("Expansion animation is not supported yet");
-			case POPOUT -> throw new UnsupportedOperationException("Popout animation is not supported yet");
-			case STATIC -> injector.getInstance(StaticBubbleAnimation.class);
-		};
-	}
+        public BubbleAnimation getAnimation(AnimationType animationType) {
+                return switch (animationType) {
+                        case EXPANSION -> injector.getInstance(ExpansionBubbleAnimation.class);
+                        case POPOUT -> injector.getInstance(PopoutBubbleAnimation.class);
+                        case STATIC -> injector.getInstance(StaticBubbleAnimation.class);
+                };
+        }
 }

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/BaseBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/BaseBubbleAnimation.java
@@ -1,0 +1,141 @@
+package me.whereareiam.socialismus.module.bubbler.common.animation.mode;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.util.Vector3f;
+import com.google.inject.Inject;
+import me.whereareiam.socialismus.api.Logger;
+import me.whereareiam.socialismus.api.model.player.DummyPlayer;
+import me.whereareiam.socialismus.api.model.scheduler.DelayedRunnableTask;
+import me.whereareiam.socialismus.api.output.Scheduler;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.*;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.PassengerPacket;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.DestroyEntitiesPacket;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.TextDisplayPacket;
+import me.whereareiam.socialismus.module.bubbler.common.animation.BubbleQueue;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Base implementation that provides queue handling and common packet utilities
+ * for different bubble animations.
+ */
+public abstract class BaseBubbleAnimation extends BubbleAnimation {
+
+protected final ConcurrentHashMap<DummyPlayer, BubbleQueue> playerQueues = new ConcurrentHashMap<>();
+
+@Inject
+protected BaseBubbleAnimation(Scheduler scheduler) {
+super(scheduler);
+}
+
+@Override
+public void display(BubbleMessage bubbleMessage) {
+Logger.debug("Displaying bubble message for: " + bubbleMessage.getSender().getUsername());
+
+BubbleQueue queue = playerQueues.computeIfAbsent(bubbleMessage.getSender(), p -> new BubbleQueue());
+queue.addMessage(bubbleMessage);
+
+if (!queue.isProcessing()) {
+processNextMessageInQueue(bubbleMessage.getSender(), queue);
+}
+}
+
+protected void processNextMessageInQueue(DummyPlayer sender, BubbleQueue queue) {
+queue.processNextGroup(
+(message, group) -> showGroupAndScheduleRemoval(sender, message, group, queue),
+() -> processNextMessageInQueue(sender, queue)
+);
+}
+
+protected void showGroupAndScheduleRemoval(DummyPlayer sender, BubbleMessage bubbleMessage, BubbleGroup group, BubbleQueue queue) {
+Logger.debug("Showing group for bubbleMessage from " + bubbleMessage.getSender().getUsername());
+
+Set<DummyPlayer> recipients = bubbleMessage.getRecipients();
+Bubble bubble = bubbleMessage.getBubble();
+float headLineGap = bubble.getDisplay().getHeadLineGap();
+float lineSpacing = bubble.getDisplay().getLineSpacing();
+
+Map<DummyPlayer, List<Integer>> recipientEntityMap = new HashMap<>();
+
+List<Integer> entityIds = new ArrayList<>();
+List<BubbleLine> lines = group.getLines();
+
+spawnLines(sender, recipients, bubble, lines, headLineGap, lineSpacing, recipientEntityMap, entityIds);
+
+long delayMs = group.calculateDisplayTime() * 1000L;
+scheduler.schedule(
+DelayedRunnableTask.builder()
+.module("bubbler")
+.delay(delayMs)
+.runnable(() -> {
+destroyGroupEntities(recipientEntityMap);
+
+queue.setProcessing(false);
+
+if (!bubbleMessage.getGroups().isEmpty()) {
+processNextMessageInQueue(sender, queue);
+} else {
+queue.getMessages().poll();
+processNextMessageInQueue(sender, queue);
+}
+})
+.build()
+);
+}
+
+protected TextDisplayPacket createTextDisplayPacket(Bubble bubble, BubbleLine line, float yOffset) {
+Bubble.Style style = bubble.getStyle();
+
+Vector3f scale = style.getScale() != null ? style.getScale().toVector3f() : new Vector3f(1.0F, 1.0F, 1.0F);
+
+return TextDisplayPacket.builder()
+.text(line.getContent())
+.type(style.getDisplay())
+.backgroundColor(style.getBackground().getColor())
+.transparency(style.getBackground().getTransparency())
+.alignment(style.getText().getAlignment())
+.hasShadow(style.getText().isShadow())
+.isSeeThrough(style.isSeeThrough())
+.translation(new Vector3f(0, yOffset, 0))
+.scale(scale)
+.build();
+}
+
+protected PassengerPacket createPassengerPacket(User user, List<Integer> entityIds) {
+Logger.debug("Creating passenger packet for user: " + user.getProfile().getName());
+return PassengerPacket.builder()
+.passengerIds(entityIds.stream().mapToInt(Integer::intValue).toArray())
+.vehicleId(user.getEntityId())
+.build();
+}
+
+protected void destroyGroupEntities(Map<DummyPlayer, List<Integer>> entities) {
+Logger.debug("Destroying displayed entities for " + entities.size() + " recipients");
+entities.forEach((recipient, entityIds) -> {
+User user = PacketEvents.getAPI().getPlayerManager().getUser(recipient.getAudience());
+if (user != null) {
+DestroyEntitiesPacket.builder()
+.entityIds(entityIds.stream().mapToInt(Integer::intValue).toArray())
+.build()
+.send(user);
+}
+});
+}
+
+protected User getUser(DummyPlayer dummyPlayer) {
+return PacketEvents.getAPI().getPlayerManager().getUser(dummyPlayer.getAudience());
+}
+
+protected abstract void spawnLines(
+DummyPlayer sender,
+Set<DummyPlayer> recipients,
+Bubble bubble,
+List<BubbleLine> lines,
+float headLineGap,
+float lineSpacing,
+Map<DummyPlayer, List<Integer>> recipientEntityMap,
+List<Integer> entityIds
+);
+}

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/ExpansionBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/ExpansionBubbleAnimation.java
@@ -1,18 +1,80 @@
 package me.whereareiam.socialismus.module.bubbler.common.animation.mode;
 
-import jakarta.inject.Inject;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import me.whereareiam.socialismus.api.output.Scheduler;
-import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleAnimation;
-import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleMessage;
+import me.whereareiam.socialismus.api.model.player.DummyPlayer;
+import me.whereareiam.socialismus.api.model.scheduler.DelayedRunnableTask;
+import me.whereareiam.socialismus.module.bubbler.api.model.Vector;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleLine;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.PassengerPacket;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.DisplayMetadataPacket;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.TextDisplayPacket;
+import com.github.retrooper.packetevents.util.Vector3f;
 
-public class ExpansionBubbleAnimation extends BubbleAnimation {
-    @Inject
-    public ExpansionBubbleAnimation(Scheduler scheduler) {
-        super(scheduler);
-    }
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-    @Override
-    public void display(BubbleMessage bubbleMessage) {
+@Singleton
+public class ExpansionBubbleAnimation extends BaseBubbleAnimation {
 
-    }
+@Inject
+public ExpansionBubbleAnimation(Scheduler scheduler) {
+super(scheduler);
+}
+
+@Override
+protected void spawnLines(
+DummyPlayer sender,
+Set<DummyPlayer> recipients,
+Bubble bubble,
+List<BubbleLine> lines,
+float headLineGap,
+float lineSpacing,
+Map<DummyPlayer, List<Integer>> recipientEntityMap,
+List<Integer> entityIds
+) {
+Vector styleScale = bubble.getStyle().getScale();
+Vector3f targetScale = styleScale != null ? styleScale.toVector3f() : new Vector3f(1.0F, 1.0F, 1.0F);
+
+for (int i = 0; i < lines.size(); i++) {
+BubbleLine line = lines.get(i);
+float yOffset = headLineGap + (i * lineSpacing);
+
+Vector3f initialScale = new Vector3f(0.1F, 0.1F, 0.1F);
+
+TextDisplayPacket textPacket = TextDisplayPacket.builder()
+.text(line.getContent())
+.type(bubble.getStyle().getDisplay())
+.backgroundColor(bubble.getStyle().getBackground().getColor())
+.transparency(bubble.getStyle().getBackground().getTransparency())
+.alignment(bubble.getStyle().getText().getAlignment())
+.hasShadow(bubble.getStyle().getText().isShadow())
+.isSeeThrough(bubble.getStyle().isSeeThrough())
+.translation(new Vector3f(0, yOffset, 0))
+.scale(initialScale)
+.build();
+recipients.forEach(r -> textPacket.send(getUser(r)));
+entityIds.add(textPacket.getEntityId());
+
+PassengerPacket passengerPacket = createPassengerPacket(getUser(sender), entityIds);
+recipients.forEach(r -> passengerPacket.send(getUser(r)));
+recipientEntityMap.put(sender, new ArrayList<>(entityIds));
+
+DisplayMetadataPacket metaPacket = DisplayMetadataPacket.builder()
+.entityId(textPacket.getEntityId())
+.scale(targetScale)
+.build();
+scheduler.schedule(
+DelayedRunnableTask.builder()
+.module("bubbler")
+.delay(100L)
+.runnable(() -> recipients.forEach(u -> metaPacket.send(getUser(u))))
+.build()
+);
+}
+}
 }

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/PopoutBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/PopoutBubbleAnimation.java
@@ -1,18 +1,57 @@
 package me.whereareiam.socialismus.module.bubbler.common.animation.mode;
 
-import jakarta.inject.Inject;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import me.whereareiam.socialismus.api.output.Scheduler;
-import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleAnimation;
-import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleMessage;
+import me.whereareiam.socialismus.api.model.player.DummyPlayer;
+import me.whereareiam.socialismus.api.model.scheduler.DelayedRunnableTask;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleLine;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.PassengerPacket;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.TextDisplayPacket;
 
-public class PopoutBubbleAnimation extends BubbleAnimation {
-    @Inject
-    public PopoutBubbleAnimation(Scheduler scheduler) {
-        super(scheduler);
-    }
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-    @Override
-    public void display(BubbleMessage bubbleMessage) {
+@Singleton
+public class PopoutBubbleAnimation extends BaseBubbleAnimation {
 
-    }
+@Inject
+public PopoutBubbleAnimation(Scheduler scheduler) {
+super(scheduler);
+}
+
+@Override
+protected void spawnLines(
+DummyPlayer sender,
+Set<DummyPlayer> recipients,
+Bubble bubble,
+List<BubbleLine> lines,
+float headLineGap,
+float lineSpacing,
+Map<DummyPlayer, List<Integer>> recipientEntityMap,
+List<Integer> entityIds
+) {
+for (int i = 0; i < lines.size(); i++) {
+BubbleLine line = lines.get(i);
+float yOffset = headLineGap + (i * lineSpacing);
+long delay = i * 200L;
+scheduler.schedule(
+DelayedRunnableTask.builder()
+.module("bubbler")
+.delay(delay)
+.runnable(() -> {
+TextDisplayPacket packet = createTextDisplayPacket(bubble, line, yOffset);
+recipients.forEach(r -> packet.send(getUser(r)));
+entityIds.add(packet.getEntityId());
+PassengerPacket passenger = createPassengerPacket(getUser(sender), entityIds);
+recipients.forEach(r -> passenger.send(getUser(r)));
+recipientEntityMap.put(sender, new ArrayList<>(entityIds));
+})
+.build()
+);
+}
+}
 }

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/StaticBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/StaticBubbleAnimation.java
@@ -1,139 +1,51 @@
 package me.whereareiam.socialismus.module.bubbler.common.animation.mode;
 
-import com.github.retrooper.packetevents.PacketEvents;
-import com.github.retrooper.packetevents.protocol.player.User;
-import com.github.retrooper.packetevents.util.Vector3f;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import me.whereareiam.socialismus.api.Logger;
-import me.whereareiam.socialismus.api.model.player.DummyPlayer;
-import me.whereareiam.socialismus.api.model.scheduler.DelayedRunnableTask;
 import me.whereareiam.socialismus.api.output.Scheduler;
 import me.whereareiam.socialismus.api.util.ComponentUtil;
-import me.whereareiam.socialismus.module.bubbler.api.model.bubble.*;
+import me.whereareiam.socialismus.api.model.player.DummyPlayer;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleLine;
 import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.PassengerPacket;
-import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.DestroyEntitiesPacket;
 import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.TextDisplayPacket;
-import me.whereareiam.socialismus.module.bubbler.common.animation.BubbleQueue;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Singleton
-public class StaticBubbleAnimation extends BubbleAnimation {
+public class StaticBubbleAnimation extends BaseBubbleAnimation {
 
-	private final ConcurrentHashMap<DummyPlayer, BubbleQueue> playerQueues = new ConcurrentHashMap<>();
+@Inject
+public StaticBubbleAnimation(Scheduler scheduler) {
+super(scheduler);
+}
 
-	@Inject
-	public StaticBubbleAnimation(Scheduler scheduler) {
-		super(scheduler);
-	}
+@Override
+protected void spawnLines(
+DummyPlayer sender,
+Set<DummyPlayer> recipients,
+Bubble bubble,
+List<BubbleLine> lines,
+float headLineGap,
+float lineSpacing,
+Map<DummyPlayer, List<Integer>> recipientEntityMap,
+List<Integer> entityIds
+) {
+for (int i = 0; i < lines.size(); i++) {
+BubbleLine line = lines.get(i);
+float yOffset = headLineGap + (i * lineSpacing);
 
-	@Override
-	public void display(BubbleMessage bubbleMessage) {
-		Logger.debug("Displaying bubble message for: " + bubbleMessage.getSender().getUsername());
+TextDisplayPacket textPacket = createTextDisplayPacket(bubble, line, yOffset);
+recipients.forEach(r -> textPacket.send(getUser(r)));
+entityIds.add(textPacket.getEntityId());
+}
 
-		BubbleQueue queue = playerQueues.computeIfAbsent(bubbleMessage.getSender(), p -> new BubbleQueue());
-		queue.addMessage(bubbleMessage);
-
-		if (!queue.isProcessing())
-			processNextMessageInQueue(bubbleMessage.getSender(), queue);
-	}
-
-	private void processNextMessageInQueue(DummyPlayer sender, BubbleQueue queue) {
-		queue.processNextGroup(
-				(message, group) -> showGroupAndScheduleRemoval(sender, message, group, queue),
-				() -> processNextMessageInQueue(sender, queue)
-		);
-	}
-
-	private void showGroupAndScheduleRemoval(DummyPlayer sender, BubbleMessage bubbleMessage, BubbleGroup group, BubbleQueue queue) {
-		Logger.debug("Showing group for bubbleMessage from " + bubbleMessage.getSender().getUsername());
-
-		Set<DummyPlayer> recipients = bubbleMessage.getRecipients();
-		Bubble bubble = bubbleMessage.getBubble();
-		float headLineGap = bubble.getDisplay().getHeadLineGap();
-		float lineSpacing = bubble.getDisplay().getLineSpacing();
-
-		Map<DummyPlayer, List<Integer>> recipientEntityMap = new HashMap<>();
-
-		List<Integer> entityIds = new ArrayList<>();
-		List<BubbleLine> lines = group.getLines();
-
-		for (int i = 0; i < lines.size(); i++) {
-			BubbleLine line = lines.get(i);
-			float yOffset = headLineGap + (i * lineSpacing);
-
-			Logger.debug("Creating TextDisplayPacket for line: " + ComponentUtil.toPlain(line.getContent()) + " [" + i + "]");
-			TextDisplayPacket textPacket = createTextDisplayPacket(bubble, line, yOffset);
-			recipients.forEach(r -> textPacket.send(getUser(r)));
-			entityIds.add(textPacket.getEntityId());
-		}
-
-		if (!entityIds.isEmpty()) {
-			PassengerPacket passengerPacket = createPassengerPacket(getUser(sender), entityIds);
-			recipients.forEach(r -> passengerPacket.send(getUser(r)));
-			recipientEntityMap.put(sender, entityIds);
-		}
-
-		long delayMs = group.calculateDisplayTime() * 1000L;
-		scheduler.schedule(
-				DelayedRunnableTask.builder()
-						.module("bubbler")
-						.delay(delayMs)
-						.runnable(() -> {
-							destroyGroupEntities(recipientEntityMap);
-
-							queue.setProcessing(false);
-
-							if (!bubbleMessage.getGroups().isEmpty()) {
-								processNextMessageInQueue(sender, queue);
-							} else {
-								queue.getMessages().poll();
-								processNextMessageInQueue(sender, queue);
-							}
-						})
-						.build()
-		);
-	}
-
-	private TextDisplayPacket createTextDisplayPacket(Bubble bubble, BubbleLine line, float yOffset) {
-		Bubble.Style style = bubble.getStyle();
-
-		return TextDisplayPacket.builder()
-				.text(line.getContent())
-				.type(style.getDisplay())
-				.backgroundColor(style.getBackground().getColor())
-				.transparency(style.getBackground().getTransparency())
-				.alignment(style.getText().getAlignment())
-				.hasShadow(style.getText().isShadow())
-				.isSeeThrough(style.isSeeThrough())
-				.translation(new Vector3f(0, yOffset, 0))
-				.build();
-	}
-
-	private PassengerPacket createPassengerPacket(User user, List<Integer> entityIds) {
-		Logger.debug("Creating passenger packet for user: " + user.getProfile().getName());
-		return PassengerPacket.builder()
-				.passengerIds(entityIds.stream().mapToInt(Integer::intValue).toArray())
-				.vehicleId(user.getEntityId())
-				.build();
-	}
-
-	private void destroyGroupEntities(Map<DummyPlayer, List<Integer>> entities) {
-		Logger.debug("Destroying displayed entities for " + entities.size() + " recipients");
-		entities.forEach((recipient, entityIds) -> {
-			User user = PacketEvents.getAPI().getPlayerManager().getUser(recipient.getAudience());
-			if (user != null) {
-				DestroyEntitiesPacket.builder()
-						.entityIds(entityIds.stream().mapToInt(Integer::intValue).toArray())
-						.build()
-						.send(user);
-			}
-		});
-	}
-
-	private User getUser(DummyPlayer dummyPlayer) {
-		return PacketEvents.getAPI().getPlayerManager().getUser(dummyPlayer.getAudience());
-	}
+if (!entityIds.isEmpty()) {
+PassengerPacket passengerPacket = createPassengerPacket(getUser(sender), entityIds);
+recipients.forEach(r -> passengerPacket.send(getUser(r)));
+recipientEntityMap.put(sender, entityIds);
+}
+}
 }


### PR DESCRIPTION
## Summary
- extract common queueing logic into `BaseBubbleAnimation`
- update `StaticBubbleAnimation`, `ExpansionBubbleAnimation`, and `PopoutBubbleAnimation` to extend the new base class
- animations no longer extend each other

## Testing
- `./gradlew build` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684055bbceb883238042f6c66bcc9ab6