### PR TITLE
Add legacy support

### DIFF
--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/BubbleCoordinationService.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/BubbleCoordinationService.java
@@ -2,6 +2,16 @@ package me.whereareiam.socialismus.module.bubbler.api;
 
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleMessage;
 
+/**
+ * Service responsible for coordinating the display and lifecycle of chat bubbles.
+ * Handles the orchestration of bubble rendering, animation, and removal for players.
+ */
 public interface BubbleCoordinationService {
+    /**
+     * Coordinates the display of a bubble message to recipients.
+     * This includes spawning the bubble, managing its animation, and scheduling removal.
+     *
+     * @param bubbleMessage the bubble message containing sender, recipients, and display configuration
+     */
     void coordinate(BubbleMessage bubbleMessage);
 }

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/VersionResolver.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/VersionResolver.java
@@ -10,7 +10,6 @@ import java.util.Map;
  * Helps packets find the correct index/type for the current protocol version.
  */
 public final class VersionResolver {
-	
 	/**
 	 * Resolves a value from a version map based on the current protocol version.
 	 * Finds the highest version <= current version that has a mapping.

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/Vector.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/Vector.java
@@ -1,15 +1,21 @@
 package me.whereareiam.socialismus.module.bubbler.api.model;
 
-import com.github.retrooper.packetevents.util.Vector3f;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * A simple 3D vector with float components.
+ * Used for representing scale, translation, and other vector-based properties.
+ */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class Vector {
+    /** The X component of the vector */
     private float x;
+    /** The Y component of the vector */
     private float y;
+    /** The Z component of the vector */
     private float z;
 }

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/bubble/Bubble.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/bubble/Bubble.java
@@ -14,6 +14,11 @@ import me.whereareiam.socialismus.type.chat.Participants;
 
 import java.util.Map;
 
+/**
+ * Represents a chat bubble configuration with display settings, formatting, and styling.
+ * Bubbles are rendered above players when they send messages and can be customized
+ * through various properties like animations, text styles, and transition effects.
+ */
 @Getter
 @ToString
 @NoArgsConstructor
@@ -29,6 +34,9 @@ public class Bubble {
 	private Map<TransitionType, BubbleTransition> transitions;
 	private Map<Participants, RequirementGroup> requirements;
 
+	/**
+	 * Display configuration controlling visibility and timing of bubbles.
+	 */
 	@Getter
 	@ToString
 	@NoArgsConstructor
@@ -45,6 +53,9 @@ public class Bubble {
 		private double minimumTime;
 	}
 
+	/**
+	 * Format configuration for bubble text content.
+	 */
 	@Getter
 	@ToString
 	@NoArgsConstructor
@@ -57,6 +68,9 @@ public class Bubble {
 		private String separatorFormat;
 	}
 
+	/**
+	 * Visual styling configuration for bubble appearance.
+	 */
 	@Getter
 	@ToString
 	@NoArgsConstructor
@@ -70,6 +84,9 @@ public class Bubble {
 		private BackgroundStyle background;
 		private TextStyle text;
 
+		/**
+		 * Background styling for the bubble.
+		 */
 		@Getter
 		@ToString
 		@NoArgsConstructor
@@ -78,6 +95,11 @@ public class Bubble {
 			private String color;
 			private short transparency;
 
+			/**
+			 * Parses the hex color string to an integer value.
+			 *
+			 * @return the color as an integer
+			 */
 			public int getColor() {
 				return Integer.parseInt(
 						color.replace("#", ""),
@@ -86,12 +108,16 @@ public class Bubble {
 			}
 		}
 
+		/**
+		 * Text styling for the bubble content.
+		 */
 		@Getter
 		@ToString
 		@NoArgsConstructor
 		@SuperBuilder(toBuilder = true)
 		public static class TextStyle {
 			private AlignmentType alignment;
+			/** Whether text has a drop shadow */
 			private boolean shadow;
 		}
 	}

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/bubble/BubbleAnimation.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/bubble/BubbleAnimation.java
@@ -2,12 +2,28 @@ package me.whereareiam.socialismus.module.bubbler.api.model.bubble;
 
 import me.whereareiam.socialismus.service.Scheduler;
 
+/**
+ * Abstract base class for bubble display animations.
+ * Implementations define how bubbles are animated when appearing,
+ * displaying content, and disappearing.
+ */
 public abstract class BubbleAnimation {
   protected final Scheduler scheduler;
 
+  /**
+   * Creates a new bubble animation with the given scheduler.
+   *
+   * @param scheduler the scheduler for timing animation tasks
+   */
   protected BubbleAnimation(Scheduler scheduler) {
     this.scheduler = scheduler;
   }
 
+  /**
+   * Displays the bubble message with this animation style.
+   * Implementations should handle spawning, animating, and cleanup.
+   *
+   * @param bubbleMessage the message to display as a bubble
+   */
   public abstract void display(BubbleMessage bubbleMessage);
 }

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/bubble/BubbleGroup.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/bubble/BubbleGroup.java
@@ -6,12 +6,23 @@ import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
+/**
+ * Represents a group of bubble lines that are displayed together.
+ * Groups are used to batch multiple lines of text that should appear
+ * and disappear as a unit.
+ */
 @Getter
 @SuperBuilder
 @AllArgsConstructor
 public class BubbleGroup {
 	private List<BubbleLine> lines;
 
+	/**
+	 * Calculates the total display time for this group.
+	 * The total is the sum of all individual line display times.
+	 *
+	 * @return the total display time in milliseconds
+	 */
 	public long calculateDisplayTime() {
 		return lines.stream().mapToLong(BubbleLine::getDisplayTime).sum();
 	}

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/bubble/BubbleLine.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/bubble/BubbleLine.java
@@ -6,6 +6,10 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import net.kyori.adventure.text.Component;
 
+/**
+ * Represents a single line of text within a bubble.
+ * Each line has its own content and display duration.
+ */
 @Getter
 @Setter
 @ToString

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/bubble/BubbleMessage.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/bubble/BubbleMessage.java
@@ -5,6 +5,7 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import me.whereareiam.socialismus.model.player.SocialismusPlayer;
+import me.whereareiam.socialismus.module.bubbler.api.type.ActivatorType;
 import net.kyori.adventure.text.Component;
 
 import java.util.Collection;
@@ -26,5 +27,6 @@ public class BubbleMessage {
   private Queue<BubbleGroup> groups;
 
   private Component content;
+  private ActivatorType activatorType;
   private boolean cancelled;
 }

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/bubble/BubbleMessage.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/bubble/BubbleMessage.java
@@ -10,6 +10,10 @@ import net.kyori.adventure.text.Component;
 import java.util.Collection;
 import java.util.Queue;
 
+/**
+ * Represents a complete bubble message ready for display.
+ * Contains the sender, recipients, bubble configuration, and formatted content.
+ */
 @Getter
 @Setter
 @ToString

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/bubble/BubbleTransition.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/bubble/BubbleTransition.java
@@ -5,6 +5,10 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
+/**
+ * Represents a transition effect that occurs during bubble lifecycle phases.
+ * Transitions can include sound effects and other feedback.
+ */
 @Getter
 @ToString
 @NoArgsConstructor
@@ -12,6 +16,9 @@ import lombok.experimental.SuperBuilder;
 public class BubbleTransition {
 	private Sound sound;
 
+	/**
+	 * Sound effect configuration for bubble transitions.
+	 */
 	@Getter
 	@ToString
 	@NoArgsConstructor

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/Packet.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/Packet.java
@@ -2,6 +2,15 @@ package me.whereareiam.socialismus.module.bubbler.api.model.packet;
 
 import com.github.retrooper.packetevents.protocol.player.User;
 
+/**
+ * Base interface for all packet types used in bubble rendering.
+ * Packets encapsulate Minecraft protocol data and handle sending to clients.
+ */
 public interface Packet {
+	/**
+	 * Sends this packet to the specified user.
+	 *
+	 * @param user the PacketEvents user to send the packet to
+	 */
 	void send(User user);
 }

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/PassengerPacket.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/PassengerPacket.java
@@ -5,6 +5,10 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSe
 import lombok.experimental.SuperBuilder;
 import me.whereareiam.socialismus.module.bubbler.api.model.packet.Packet;
 
+/**
+ * Packet for mounting entities as passengers on a vehicle entity.
+ * Used to attach bubble display entities to invisible carrier entities.
+ */
 @SuperBuilder
 public class PassengerPacket implements Packet {
 	private final int vehicleId;

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/AreaEffectCloudPacket.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/AreaEffectCloudPacket.java
@@ -17,10 +17,20 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Packet for spawning an area effect cloud entity.
+ * Used as an invisible carrier entity for mounting bubble displays
+ * on older Minecraft versions.
+ */
 @Getter
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
 public class AreaEffectCloudPacket extends EntityPacket {
 	private final float radius;
+
+	/** Version-specific metadata index for the radius field */
+	private static final Map<Version, Integer> RADIUS_INDEX = Map.of(
+			Version.V_1_16, 8
+	);
 
 	@Override
 	public void send(User user) {
@@ -42,12 +52,11 @@ public class AreaEffectCloudPacket extends EntityPacket {
 		List<EntityData<?>> metadata = new ArrayList<>();
 		addCommonMetadata(metadata);
 
-		Map<Version, Integer> radiusIndex = Map.of(
-				Version.V_1_21_4, 8
-		);
-
-		Integer index = VersionResolver.resolve(radiusIndex, null);
-		if (index != null) metadata.add(new EntityData<>(index, EntityDataTypes.FLOAT, radius));
+		metadata.add(new EntityData<>(
+				VersionResolver.resolveOrThrow(RADIUS_INDEX),
+				EntityDataTypes.FLOAT,
+				radius
+		));
 
 		return new WrapperPlayServerEntityMetadata(entityId, metadata);
 	}

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/DestroyEntitiesPacket.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/DestroyEntitiesPacket.java
@@ -5,6 +5,10 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerDe
 import lombok.experimental.SuperBuilder;
 import me.whereareiam.socialismus.module.bubbler.api.model.packet.Packet;
 
+/**
+ * Packet for removing entities from the client.
+ * Used to clean up bubble display entities when they expire or are cancelled.
+ */
 @SuperBuilder
 public class DestroyEntitiesPacket implements Packet {
 	private final int[] entityIds;

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/EntityPacket.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/EntityPacket.java
@@ -12,6 +12,10 @@ import me.whereareiam.socialismus.type.Version;
 
 import java.util.List;
 
+/**
+ * Abstract base class for entity spawn packets.
+ * Provides common entity properties like ID, position, and gravity settings.
+ */
 @Getter
 @SuperBuilder(toBuilder = true)
 public abstract class EntityPacket implements Packet {
@@ -21,6 +25,12 @@ public abstract class EntityPacket implements Packet {
 	protected final Vector3d position = new Vector3d(0.0F, 0.0F, 0.0F);
 	protected final boolean noGravity;
 
+	/**
+	 * Adds common entity metadata to the metadata list.
+	 * Handles version-specific differences in the no-gravity flag.
+	 *
+	 * @param metadata the metadata list to add to
+	 */
 	protected void addCommonMetadata(List<EntityData<?>> metadata) {
 		if (Constants.SERVER_VERSION.isAtLeast(Version.V_1_19_4)) {
 			metadata.add(new EntityData<>(5, EntityDataTypes.BOOLEAN, noGravity));

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/display/DisplayPacket.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/display/DisplayPacket.java
@@ -19,6 +19,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Base packet for spawning display entities (1.19.4+).
+ * Display entities provide high-quality text and model rendering.
+ */
 @Getter
 @SuperBuilder(toBuilder = true)
 public class DisplayPacket extends EntityPacket {
@@ -28,6 +32,12 @@ public class DisplayPacket extends EntityPacket {
 	private final Vector3f scale = new Vector3f(1.0F, 1.0F, 1.0F);
 	private final DisplayType type;
 
+	/**
+	 * Adds display-specific metadata to the metadata list.
+	 * Includes translation, scale, and billboard type.
+	 *
+	 * @param metadata the metadata list to add to
+	 */
 	protected void addDisplayMetadata(List<EntityData<?>> metadata) {
 		super.addCommonMetadata(metadata);
 

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/display/TextDisplayPacket.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/display/TextDisplayPacket.java
@@ -19,6 +19,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Packet for spawning a text display entity (1.19.4+).
+ * Text displays provide rich text rendering with customizable styling,
+ * background, and alignment options.
+ */
 @Getter
 @SuperBuilder(toBuilder = true)
 public class TextDisplayPacket extends DisplayPacket {

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/display/metadata/InterpolationMetadataPacket.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/display/metadata/InterpolationMetadataPacket.java
@@ -13,6 +13,10 @@ import me.whereareiam.socialismus.type.Version;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Metadata packet for configuring display entity interpolation settings.
+ * Interpolation allows smooth transitions between transform states.
+ */
 @Getter
 @SuperBuilder
 public class InterpolationMetadataPacket implements Packet {

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/display/metadata/ScaleMetadataPacket.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/display/metadata/ScaleMetadataPacket.java
@@ -14,6 +14,10 @@ import me.whereareiam.socialismus.type.Version;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Metadata packet for updating a display entity's scale.
+ * Used for animations that grow or shrink the display.
+ */
 @Getter
 @SuperBuilder
 public class ScaleMetadataPacket implements Packet {

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/display/metadata/TranslationMetadataPacket.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/display/metadata/TranslationMetadataPacket.java
@@ -13,6 +13,10 @@ import me.whereareiam.socialismus.type.Version;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Metadata packet for updating a display entity's translation offset.
+ * Used for animations that move the display relative to its position.
+ */
 @SuperBuilder
 public final class TranslationMetadataPacket implements Packet {
 	private final int entityId;

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/living/ArmorStandPacket.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/packet/type/entity/living/ArmorStandPacket.java
@@ -6,11 +6,13 @@ import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSpawnEntity;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 import me.whereareiam.socialismus.module.bubbler.api.VersionResolver;
 import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.EntityPacket;
 import me.whereareiam.socialismus.type.Version;
+import net.kyori.adventure.text.Component;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,10 +20,43 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Packet for spawning an armor stand entity with a custom name.
+ * Used for displaying bubble text on older Minecraft versions
+ * that don't support text display entities.
+ */
 @Getter
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
 public class ArmorStandPacket extends EntityPacket {
-	private final boolean small;
+	@Builder.Default
+	private final boolean small = true;
+	@Builder.Default
+	private final boolean invisible = true;
+	@Builder.Default
+	private final boolean marker = true;
+	private final Component customName;
+	@Builder.Default
+	private final boolean customNameVisible = true;
+
+	/** Version-specific metadata index for entity flags */
+	private static final Map<Version, Integer> ENTITY_FLAGS_INDEX = Map.of(
+			Version.V_1_16, 0
+	);
+
+	/** Version-specific metadata index for custom name */
+	private static final Map<Version, Integer> CUSTOM_NAME_INDEX = Map.of(
+			Version.V_1_16, 2
+	);
+
+	/** Version-specific metadata index for custom name visibility */
+	private static final Map<Version, Integer> CUSTOM_NAME_VISIBLE_INDEX = Map.of(
+			Version.V_1_16, 3
+	);
+
+	/** Version-specific metadata index for armor stand flags */
+	private static final Map<Version, Integer> ARMOR_STAND_FLAGS_INDEX = Map.of(
+			Version.V_1_16, 15
+	);
 
 	@Override
 	public void send(User user) {
@@ -43,15 +78,36 @@ public class ArmorStandPacket extends EntityPacket {
 		List<EntityData<?>> metadata = new ArrayList<>();
 		addCommonMetadata(metadata);
 
-		byte status = 0;
-		if (small) status |= 0x01;
+		byte entityFlags = 0;
+		if (invisible) entityFlags |= 0x20;
+		metadata.add(new EntityData<>(
+				VersionResolver.resolveOrThrow(ENTITY_FLAGS_INDEX),
+				EntityDataTypes.BYTE,
+				entityFlags
+		));
 
-		Map<Version, Integer> statusIndex = Map.of(
-				Version.V_1_21_4, 15
-		);
+		if (customName != null) {
+			metadata.add(new EntityData<>(
+					VersionResolver.resolveOrThrow(CUSTOM_NAME_INDEX),
+					EntityDataTypes.OPTIONAL_ADV_COMPONENT,
+					Optional.of(customName)
+			));
+		}
 
-		Integer index = VersionResolver.resolve(statusIndex, null);
-		if (index != null) metadata.add(new EntityData<>(index, EntityDataTypes.BYTE, status));
+		metadata.add(new EntityData<>(
+				VersionResolver.resolveOrThrow(CUSTOM_NAME_VISIBLE_INDEX),
+				EntityDataTypes.BOOLEAN,
+				customNameVisible
+		));
+
+		byte armorStandFlags = 0;
+		if (small) armorStandFlags |= 0x01;
+		if (marker) armorStandFlags |= 0x10;
+		metadata.add(new EntityData<>(
+				VersionResolver.resolveOrThrow(ARMOR_STAND_FLAGS_INDEX),
+				EntityDataTypes.BYTE,
+				armorStandFlags
+		));
 
 		return new WrapperPlayServerEntityMetadata(entityId, metadata);
 	}

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/requirement/ActivatorRequirement.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/model/requirement/ActivatorRequirement.java
@@ -1,0 +1,26 @@
+package me.whereareiam.socialismus.module.bubbler.api.model.requirement;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import me.whereareiam.socialismus.model.requirement.Requirement;
+
+import java.util.List;
+
+/**
+ * Requirement that checks which activator type triggered a bubble.
+ * Used to distinguish between bubbles activated via chat vs command.
+ */
+@Getter
+@Setter
+@ToString(callSuper = true)
+@NoArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class ActivatorRequirement extends Requirement {
+	/**
+	 * List of activator type names to check against (e.g., "CHAT", "COMMAND")
+	 */
+	private List<String> activators;
+}

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/renderer/BubbleRenderer.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/renderer/BubbleRenderer.java
@@ -12,9 +12,11 @@ import java.util.List;
  * Interface for rendering bubble text above players.
  * Implementations handle entity creation, positioning, animation, and cleanup
  * using different entity types (armor stands, text displays, etc.).
+ * <p>
+ * This interface contains ONLY primitive rendering operations.
+ * Complex rendering logic should be delegated to RenderStrategy implementations.
  */
 public interface BubbleRenderer {
-
 	/**
 	 * Creates the entities needed to render a bubble line.
 	 *
@@ -48,7 +50,7 @@ public interface BubbleRenderer {
 	 *
 	 * @param line the line to update
 	 * @param yOffset vertical offset from the player's eye position
-	 * @param eyePos the player's current eye position
+	 * @param eyePos the player's current eye position (can be null if not needed)
 	 * @param recipients the users to send packets to
 	 */
 	void updatePosition(RenderedLine line, float yOffset, Position eyePos, Collection<User> recipients);
@@ -62,19 +64,12 @@ public interface BubbleRenderer {
 	void destroy(RenderedLine line, Collection<User> recipients);
 
 	/**
-	 * Destroys multiple rendered lines.
+	 * Destroys multiple rendered lines efficiently.
 	 *
 	 * @param lines the lines to destroy
 	 * @param recipients the users to send packets to
 	 */
 	void destroy(List<RenderedLine> lines, Collection<User> recipients);
-
-	/**
-	 * Checks if this renderer supports scale-based animations.
-	 *
-	 * @return true if scale animations are supported
-	 */
-	boolean supportsScaleAnimation();
 
 	/**
 	 * Applies the initial scale for animation (typically zero for grow effects).
@@ -105,10 +100,19 @@ public interface BubbleRenderer {
 	void animateRemoval(RenderedLine line, Bubble bubble, Collection<User> recipients, Runnable onComplete);
 
 	/**
-	 * Gets the entity ID that should be used as the passenger anchor.
+	 * Gets the entity ID that should be used as the passenger anchor point.
+	 * This is used when chaining multiple entities together.
 	 *
 	 * @param line the rendered line
 	 * @return the entity ID for passenger mounting
 	 */
 	int getPassengerAnchorId(RenderedLine line);
+
+	/**
+	 * Gets the render strategy for this renderer.
+	 * The strategy handles complex multi-line rendering logic.
+	 *
+	 * @return the render strategy
+	 */
+	RenderStrategy getStrategy();
 }

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/renderer/BubbleRenderer.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/renderer/BubbleRenderer.java
@@ -1,0 +1,114 @@
+package me.whereareiam.socialismus.module.bubbler.api.renderer;
+
+import com.github.retrooper.packetevents.protocol.player.User;
+import me.whereareiam.socialismus.model.position.Position;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleLine;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Interface for rendering bubble text above players.
+ * Implementations handle entity creation, positioning, animation, and cleanup
+ * using different entity types (armor stands, text displays, etc.).
+ */
+public interface BubbleRenderer {
+
+	/**
+	 * Creates the entities needed to render a bubble line.
+	 *
+	 * @param bubble the bubble configuration
+	 * @param line the line content to render
+	 * @param yOffset vertical offset from the player's eye position
+	 * @param eyePos the player's eye position
+	 * @return the rendered line containing entity information
+	 */
+	RenderedLine spawnLine(Bubble bubble, BubbleLine line, float yOffset, Position eyePos);
+
+	/**
+	 * Sends spawn packets for a rendered line to recipients.
+	 *
+	 * @param renderedLine the line to spawn
+	 * @param recipients the users to send packets to
+	 */
+	void sendSpawn(RenderedLine renderedLine, Collection<User> recipients);
+
+	/**
+	 * Attaches a rendered line as a passenger of a vehicle entity.
+	 *
+	 * @param vehicleId the vehicle entity ID
+	 * @param line the line to attach
+	 * @param recipients the users to send packets to
+	 */
+	void attachAsPassenger(int vehicleId, RenderedLine line, Collection<User> recipients);
+
+	/**
+	 * Updates the position of a rendered line.
+	 *
+	 * @param line the line to update
+	 * @param yOffset vertical offset from the player's eye position
+	 * @param eyePos the player's current eye position
+	 * @param recipients the users to send packets to
+	 */
+	void updatePosition(RenderedLine line, float yOffset, Position eyePos, Collection<User> recipients);
+
+	/**
+	 * Destroys a single rendered line.
+	 *
+	 * @param line the line to destroy
+	 * @param recipients the users to send packets to
+	 */
+	void destroy(RenderedLine line, Collection<User> recipients);
+
+	/**
+	 * Destroys multiple rendered lines.
+	 *
+	 * @param lines the lines to destroy
+	 * @param recipients the users to send packets to
+	 */
+	void destroy(List<RenderedLine> lines, Collection<User> recipients);
+
+	/**
+	 * Checks if this renderer supports scale-based animations.
+	 *
+	 * @return true if scale animations are supported
+	 */
+	boolean supportsScaleAnimation();
+
+	/**
+	 * Applies the initial scale for animation (typically zero for grow effects).
+	 *
+	 * @param line the line to scale
+	 * @param bubble the bubble configuration
+	 * @param recipients the users to send packets to
+	 */
+	void applyInitialScale(RenderedLine line, Bubble bubble, Collection<User> recipients);
+
+	/**
+	 * Animates a line spawning (e.g., growing from zero to full size).
+	 *
+	 * @param line the line to animate
+	 * @param bubble the bubble configuration
+	 * @param recipients the users to send packets to
+	 */
+	void animateSpawn(RenderedLine line, Bubble bubble, Collection<User> recipients);
+
+	/**
+	 * Animates a line being removed (e.g., shrinking to zero).
+	 *
+	 * @param line the line to animate
+	 * @param bubble the bubble configuration
+	 * @param recipients the users to send packets to
+	 * @param onComplete callback to run when animation completes
+	 */
+	void animateRemoval(RenderedLine line, Bubble bubble, Collection<User> recipients, Runnable onComplete);
+
+	/**
+	 * Gets the entity ID that should be used as the passenger anchor.
+	 *
+	 * @param line the rendered line
+	 * @return the entity ID for passenger mounting
+	 */
+	int getPassengerAnchorId(RenderedLine line);
+}

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/renderer/RenderStrategy.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/renderer/RenderStrategy.java
@@ -1,0 +1,133 @@
+package me.whereareiam.socialismus.module.bubbler.api.renderer;
+
+import com.github.retrooper.packetevents.protocol.player.User;
+import me.whereareiam.socialismus.model.player.SocialismusPlayer;
+import me.whereareiam.socialismus.model.position.Position;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleGroup;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleLine;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Strategy for handling complex multi-line rendering operations.
+ * 
+ * <p>Each renderer provides its own strategy that encapsulates renderer-specific logic
+ * for handling multi-line scenarios like static groups and stacked animations.
+ * 
+ * <h2>Why Use Strategies?</h2>
+ * Different entity types have fundamentally different rendering approaches:
+ * <ul>
+ *   <li><b>TextDisplays:</b> Use batch attachment and metadata for positioning</li>
+ *   <li><b>ArmorStands:</b> Use passenger chaining with spacer entities</li>
+ * </ul>
+ * 
+ * <p>By encapsulating these differences in strategies, animations can remain format-agnostic
+ * and simply call strategy methods without knowing whether they're working with text displays
+ * or armor stands.
+ * 
+ * @see me.whereareiam.socialismus.module.bubbler.common.renderer.strategy.TextDisplayRenderStrategy
+ * @see me.whereareiam.socialismus.module.bubbler.common.renderer.strategy.ArmorStandRenderStrategy
+ */
+public interface RenderStrategy {
+	/**
+	 * Spawns multiple lines for static display (all at once).
+	 * 
+	 * <p>Used by static animations where all lines appear simultaneously.
+	 * Each strategy handles attachment differently:
+	 * <ul>
+	 *   <li><b>TextDisplays:</b> Spawn all at calculated positions, batch attach to player</li>
+	 *   <li><b>ArmorStands:</b> Build passenger chain from player down through all lines</li>
+	 * </ul>
+	 *
+	 * @param bubble the bubble configuration
+	 * @param group the group of lines to spawn
+	 * @param headGap gap from head
+	 * @param spacing spacing between lines
+	 * @param eyePos the player's eye position
+	 * @param sender the player entity
+	 * @param recipients the users to send packets to
+	 * @return list of rendered lines
+	 */
+	List<RenderedLine> spawnStaticGroup(
+			Bubble bubble,
+			BubbleGroup group,
+			float headGap,
+			float spacing,
+			Position eyePos,
+			SocialismusPlayer sender,
+			Collection<User> recipients
+	);
+
+	/**
+	 * Spawns a single line in a stacked animation context.
+	 * 
+	 * <p>Called when a new line spawns in a stacked animation. The strategy determines
+	 * what type of line to create based on context:
+	 * <ul>
+	 *   <li><b>TextDisplays:</b> Always spawns with headGap offset</li>
+	 *   <li><b>ArmorStands:</b> First line without spacer, subsequent lines with spacer</li>
+	 * </ul>
+	 *
+	 * @param bubble the bubble configuration
+	 * @param line the line content to render
+	 * @param eyePos the player's eye position
+	 * @param existingLines previously rendered lines in the stack
+	 * @return the rendered line
+	 */
+	RenderedLine spawnStackedLine(
+			Bubble bubble,
+			BubbleLine line,
+			Position eyePos,
+			List<RenderedLine> existingLines
+	);
+
+	/**
+	 * Updates positions of multiple stacked lines and reattaches them.
+	 * 
+	 * <p>Called when lines are removed from the stack (popout/overflow) to maintain
+	 * correct positioning and attachment. Each strategy handles this differently:
+	 * <ul>
+	 *   <li><b>TextDisplays:</b> Updates Y positions via translation metadata, batch reattaches</li>
+	 *   <li><b>ArmorStands:</b> Rebuilds the entire passenger chain from scratch</li>
+	 * </ul>
+	 *
+	 * @param sender the player these bubbles belong to
+	 * @param lines the lines to update
+	 * @param headGap gap from head
+	 * @param spacing spacing between lines
+	 * @param recipients the users to send packets to
+	 */
+	void updateStackedPositions(
+			SocialismusPlayer sender,
+			List<RenderedLine> lines,
+			float headGap,
+			float spacing,
+			Collection<User> recipients
+	);
+
+	/**
+	 * Attaches a newly spawned line in stacked animation, pushing existing lines down.
+	 * 
+	 * <p>Called immediately after spawning a new line, BEFORE adding it to the list.
+	 * This allows renderer-specific incremental attachment without full rebuilds.
+	 * 
+	 * <p>Behavior by renderer:
+	 * <ul>
+	 *   <li><b>TextDisplays:</b> No-op (batch attachment handled in updateStackedPositions)</li>
+	 *   <li><b>ArmorStands:</b> Incrementally rebuilds chain to avoid visual glitches</li>
+	 * </ul>
+	 *
+	 * @param sender the player these bubbles belong to
+	 * @param newLine the newly spawned line
+	 * @param existingLines the existing lines that need to be pushed down
+	 * @param recipients the users to send packets to
+	 */
+	void attachNewStackedLine(
+			SocialismusPlayer sender,
+			RenderedLine newLine,
+			List<RenderedLine> existingLines,
+			Collection<User> recipients
+	);
+}

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/renderer/RenderedLine.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/renderer/RenderedLine.java
@@ -1,0 +1,25 @@
+package me.whereareiam.socialismus.module.bubbler.api.renderer;
+
+import java.util.List;
+
+/**
+ * Represents a rendered bubble line with its associated entity IDs.
+ * A single line may use multiple entities (e.g., a carrier and a display).
+ */
+public interface RenderedLine {
+	/**
+	 * Gets all entity IDs associated with this rendered line.
+	 * Used for cleanup when destroying the line.
+	 *
+	 * @return list of all entity IDs
+	 */
+	List<Integer> getAllEntityIds();
+
+	/**
+	 * Gets the primary entity ID for this line.
+	 * This is typically the visible display entity.
+	 *
+	 * @return the primary entity ID
+	 */
+	int getPrimaryEntityId();
+}

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/ActivatorType.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/ActivatorType.java
@@ -1,6 +1,11 @@
 package me.whereareiam.socialismus.module.bubbler.api.type;
 
+/**
+ * Defines the trigger mechanism that activates a chat bubble.
+ */
 public enum ActivatorType {
+    /** Bubble is triggered by player chat messages */
     CHAT,
+    /** Bubble is triggered by command execution */
     COMMAND
 }

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/ActivatorType.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/ActivatorType.java
@@ -1,11 +1,16 @@
 package me.whereareiam.socialismus.module.bubbler.api.type;
 
 /**
- * Defines the trigger mechanism that activates a chat bubble.
+ * Defines the mechanism that activated a bubble.
+ * Used to distinguish between bubbles triggered by chat messages vs direct commands.
  */
 public enum ActivatorType {
-    /** Bubble is triggered by player chat messages */
-    CHAT,
-    /** Bubble is triggered by command execution */
-    COMMAND
+	/**
+	 * Bubble was activated through Socialismus chat system
+	 */
+	CHAT,
+	/**
+	 * Bubble was activated through Bubbler's command
+	 */
+	COMMAND
 }

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/AlignmentType.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/AlignmentType.java
@@ -2,12 +2,20 @@ package me.whereareiam.socialismus.module.bubbler.api.type;
 
 import lombok.Getter;
 
+/**
+ * Defines the text alignment options for bubble text display entities.
+ * Values correspond to Minecraft's text display alignment flags.
+ */
 @Getter
 public enum AlignmentType {
+	/** Center-aligned text (default) */
 	CENTER(0x00),
+	/** Left-aligned text */
 	LEFT(0x08),
+	/** Right-aligned text */
 	RIGHT(0x10);
 
+	/** The protocol flag value for this alignment */
 	private final byte value;
 
 	AlignmentType(int value) {

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/AnimationType.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/AnimationType.java
@@ -1,8 +1,15 @@
 package me.whereareiam.socialismus.module.bubbler.api.type;
 
+/**
+ * Defines the animation styles for bubble appearance and disappearance.
+ */
 public enum AnimationType {
+	/** Bubble contracts/shrinks when appearing or disappearing */
 	CONTRACTION,
+	/** Bubble expands/grows when appearing or disappearing */
 	EXPANSION,
+	/** Bubble pops out with a bounce effect */
 	POPOUT,
+	/** No animation, bubble appears/disappears instantly */
 	STATIC
 }

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/BubbleType.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/BubbleType.java
@@ -1,5 +1,14 @@
 package me.whereareiam.socialismus.module.bubbler.api.type;
 
+/**
+ * Defines the entity type used to render chat bubbles.
+ * Different types offer varying compatibility and visual features.
+ */
 public enum BubbleType {
-	ARMOR_STAND, AREA_EFFECT_CLOUD, TEXT_DISPLAY
+	/** Uses armor stand entities with custom names (legacy support, works on all versions) */
+	ARMOR_STAND,
+	/** Uses area effect cloud entities (legacy support for passenger mounting) */
+	AREA_EFFECT_CLOUD,
+	/** Uses text display entities (1.19.4+, best visual quality and features) */
+	TEXT_DISPLAY
 }

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/BubbleType.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/BubbleType.java
@@ -7,8 +7,6 @@ package me.whereareiam.socialismus.module.bubbler.api.type;
 public enum BubbleType {
 	/** Uses armor stand entities with custom names (legacy support, works on all versions) */
 	ARMOR_STAND,
-	/** Uses area effect cloud entities (legacy support for passenger mounting) */
-	AREA_EFFECT_CLOUD,
 	/** Uses text display entities (1.19.4+, best visual quality and features) */
 	TEXT_DISPLAY
 }

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/DisplayType.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/DisplayType.java
@@ -2,13 +2,22 @@ package me.whereareiam.socialismus.module.bubbler.api.type;
 
 import lombok.Getter;
 
+/**
+ * Defines the billboard mode for display entities, controlling how they rotate relative to the viewer.
+ * Values correspond to Minecraft's display entity billboard modes.
+ */
 @Getter
 public enum DisplayType {
+	/** Display has a fixed rotation, does not track the viewer */
 	FIXED(0x00),
+	/** Display rotates only on the vertical axis to face the viewer */
 	VERTICAL(0x01),
+	/** Display rotates only on the horizontal axis to face the viewer */
 	HORIZONTAL(0x02),
+	/** Display always faces the viewer (full billboard mode) */
 	CENTER(0x03);
 
+	/** The protocol value for this billboard mode */
 	private final byte value;
 
 	DisplayType(int value) {

--- a/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/TransitionType.java
+++ b/bubbler-api/src/main/java/me/whereareiam/socialismus/module/bubbler/api/type/TransitionType.java
@@ -1,7 +1,13 @@
 package me.whereareiam.socialismus.module.bubbler.api.type;
 
+/**
+ * Defines the timing phases for bubble transition effects such as sounds.
+ */
 public enum TransitionType {
+    /** Transition occurs before the bubble appears */
     BEFORE,
+    /** Transition occurs after the bubble disappears */
     AFTER,
+    /** Transition occurs between bubble line groups */
     INTER
 }

--- a/bubbler-bootstrap/src/main/java/me/whereareiam/socialismus/module/bubbler/Bubbler.java
+++ b/bubbler-bootstrap/src/main/java/me/whereareiam/socialismus/module/bubbler/Bubbler.java
@@ -3,6 +3,8 @@ package me.whereareiam.socialismus.module.bubbler;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
 import lombok.RequiredArgsConstructor;
 import me.whereareiam.socialismus.Reloadable;
 import me.whereareiam.socialismus.config.ConfigurationTypeResolver;
@@ -36,6 +38,7 @@ public class Bubbler extends SocialisticModule {
 								parentInjector.getInstance(ConfigurationTypeResolver.class),
 								reloadableRegistry,
 								parentInjector.getInstance(RequirementEvaluatorService.class),
+								parentInjector.getInstance(Key.get(new TypeLiteral<>() {})),
 								parentInjector.getInstance(CommandService.class),
 								parentInjector.getInstance(PlayerRegistry.class)),
 						new CommonConfiguration(workingPath));

--- a/bubbler-bootstrap/src/main/java/me/whereareiam/socialismus/module/bubbler/BubblerInjectorConfiguration.java
+++ b/bubbler-bootstrap/src/main/java/me/whereareiam/socialismus/module/bubbler/BubblerInjectorConfiguration.java
@@ -5,12 +5,15 @@ import com.google.inject.TypeLiteral;
 import lombok.RequiredArgsConstructor;
 import me.whereareiam.socialismus.Reloadable;
 import me.whereareiam.socialismus.config.ConfigurationTypeResolver;
+import me.whereareiam.socialismus.model.requirement.RequirementKey;
 import me.whereareiam.socialismus.registry.PlayerRegistry;
+import me.whereareiam.socialismus.registry.base.ExtendedRegistry;
 import me.whereareiam.socialismus.registry.base.Registry;
 import me.whereareiam.socialismus.service.CommandService;
 import me.whereareiam.socialismus.service.PlatformInteractor;
 import me.whereareiam.socialismus.service.Scheduler;
 import me.whereareiam.socialismus.service.requirement.RequirementEvaluatorService;
+import me.whereareiam.socialismus.service.requirement.RequirementValidation;
 
 @RequiredArgsConstructor
 public class BubblerInjectorConfiguration extends AbstractModule {
@@ -20,6 +23,7 @@ public class BubblerInjectorConfiguration extends AbstractModule {
 
 	private final Registry<Reloadable> reloadableRegistry;
 	private final RequirementEvaluatorService requirementEvaluator;
+	private final ExtendedRegistry<RequirementKey<?>, RequirementValidation> requirementRegistry;
 
 	private final CommandService commandService;
 	private final PlayerRegistry playerRegistry;
@@ -32,6 +36,7 @@ public class BubblerInjectorConfiguration extends AbstractModule {
 
 		bind(RequirementEvaluatorService.class).toInstance(requirementEvaluator);
 		bind(new TypeLiteral<Registry<Reloadable>>() {}).toInstance(reloadableRegistry);
+		bind(new TypeLiteral<ExtendedRegistry<RequirementKey<?>, RequirementValidation>>() {}).toInstance(requirementRegistry);
 
 		bind(CommandService.class).toInstance(commandService);
 		bind(PlayerRegistry.class).toInstance(playerRegistry);

--- a/bubbler-command/src/main/java/me/whereareiam/socialismus/module/bubbler/command/executor/BubbleCommand.java
+++ b/bubbler-command/src/main/java/me/whereareiam/socialismus/module/bubbler/command/executor/BubbleCommand.java
@@ -7,6 +7,7 @@ import me.whereareiam.commandant.annotation.Definition;
 import me.whereareiam.socialismus.model.player.SocialismusPlayer;
 import me.whereareiam.socialismus.module.bubbler.api.BubbleCoordinationService;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleMessage;
+import me.whereareiam.socialismus.module.bubbler.api.type.ActivatorType;
 import net.kyori.adventure.text.Component;
 import org.incendo.cloud.annotations.Argument;
 import org.incendo.cloud.annotations.Command;
@@ -25,6 +26,7 @@ public class BubbleCommand {
 				.sender(player)
 				.recipients(Set.of())
 				.content(Component.text(message))
+				.activatorType(ActivatorType.COMMAND)
 				.build()
 		);
 	}

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/BubbleCoordinator.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/BubbleCoordinator.java
@@ -21,6 +21,9 @@ public class BubbleCoordinator implements BubbleCoordinationService {
 		bubbleMessage = bubbleMessageProcessor.process(bubbleMessage);
 		if (bubbleMessage.isCancelled()) return;
 
+		// Store activator type for requirement checks
+		bubbleMessage.getSender().setData(BubblerConstants.DataKeys.LAST_ACTIVATOR, bubbleMessage.getActivatorType());
+
 		Logger.debug("Animating bubble message for: " + bubbleMessage.getSender().getUsername() + " with animation: "
 				+ bubbleMessage.getBubble().getStyle().getAnimation());
 		bubbleAnimationFactory

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/BubblerConstants.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/BubblerConstants.java
@@ -1,0 +1,39 @@
+package me.whereareiam.socialismus.module.bubbler.common;
+
+import me.whereareiam.socialismus.model.player.PlayerDataKey;
+import me.whereareiam.socialismus.model.requirement.RequirementKey;
+import me.whereareiam.socialismus.module.bubbler.api.model.requirement.ActivatorRequirement;
+import me.whereareiam.socialismus.module.bubbler.api.type.ActivatorType;
+
+/**
+ * Constants for the Bubbler module.
+ * Follows the same pattern as Socialismus core Constants class.
+ */
+public final class BubblerConstants {
+	/**
+	 * Player data keys specific to Bubbler module.
+	 */
+	public static final class DataKeys {
+		/**
+		 * The last activator type that triggered a bubble for the player.
+		 */
+		public static final PlayerDataKey<ActivatorType> LAST_ACTIVATOR =
+				PlayerDataKey.create("bubbler", "last_activator", ActivatorType.class);
+	}
+
+	/**
+	 * Requirement keys specific to Bubbler module.
+	 * These extend the requirement system without modifying Socialismus core.
+	 */
+	public static final class Requirements {
+		/**
+		 * Activator-based requirements (e.g., bubble was activated via CHAT or COMMAND)
+		 */
+		public static final RequirementKey<ActivatorRequirement> ACTIVATOR =
+				RequirementKey.create("bubbler", "activator", ActivatorRequirement.class);
+	}
+
+	private BubblerConstants() {
+		// Utility class
+	}
+}

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/CommonConfiguration.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/CommonConfiguration.java
@@ -12,6 +12,7 @@ import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleMessage;
 import me.whereareiam.socialismus.module.bubbler.api.model.config.BubblerCommands;
 import me.whereareiam.socialismus.module.bubbler.api.model.config.BubblerMessages;
 import me.whereareiam.socialismus.module.bubbler.api.model.config.BubblerSettings;
+import me.whereareiam.socialismus.module.bubbler.common.config.ConfiguraBootstrap;
 import me.whereareiam.socialismus.module.bubbler.common.config.provider.BubblerCommandsProvider;
 import me.whereareiam.socialismus.module.bubbler.common.config.provider.BubblerMessagesProvider;
 import me.whereareiam.socialismus.module.bubbler.common.config.provider.BubblerSettingsProvider;
@@ -20,6 +21,7 @@ import me.whereareiam.socialismus.module.bubbler.common.processor.BubbleMessageP
 import me.whereareiam.socialismus.module.bubbler.common.worker.BubbleSelector;
 import me.whereareiam.socialismus.module.bubbler.common.worker.container.ContentArranger;
 import me.whereareiam.socialismus.module.bubbler.common.worker.container.ContentTimeEvaluator;
+import me.whereareiam.socialismus.module.bubbler.common.requirement.ActivatorRequirementValidation;
 import me.whereareiam.socialismus.module.bubbler.common.worker.recipient.RecipientResolver;
 import me.whereareiam.socialismus.module.bubbler.common.worker.recipient.RecipientSelector;
 import me.whereareiam.socialismus.registry.WorkerProcessor;
@@ -38,6 +40,7 @@ public class CommonConfiguration extends AbstractModule {
 		requestInjection(this);
 
 		// Configuration
+		bind(ConfiguraBootstrap.class).asEagerSingleton();
 		bind(BubblerSettingsProvider.class).asEagerSingleton();
 		bind(BubblerSettings.class).toProvider(BubblerSettingsProvider.class);
 
@@ -59,6 +62,9 @@ public class CommonConfiguration extends AbstractModule {
 		bind(BubbleSelector.class).asEagerSingleton();
 		bind(ContentArranger.class).asEagerSingleton();
 		bind(ContentTimeEvaluator.class).asEagerSingleton();
+
+		// Requirements
+		bind(ActivatorRequirementValidation.class).asEagerSingleton();
 	}
 
 	@Provides

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/StaticBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/StaticBubbleAnimation.java
@@ -24,9 +24,11 @@ import java.util.List;
 
 @Singleton
 public final class StaticBubbleAnimation extends AbstractQueuedAnimation {
-
 	@Inject
-	public StaticBubbleAnimation(Scheduler scheduler, BubbleRendererFactory rendererFactory) {
+	public StaticBubbleAnimation(
+			Scheduler scheduler,
+			BubbleRendererFactory rendererFactory
+	) {
 		super(scheduler, rendererFactory);
 	}
 

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/StaticBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/StaticBubbleAnimation.java
@@ -8,17 +8,14 @@ import me.whereareiam.socialismus.model.position.Position;
 import me.whereareiam.socialismus.model.scheduler.DelayedRunnableTask;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleGroup;
-import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleLine;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleMessage;
 import me.whereareiam.socialismus.module.bubbler.api.renderer.BubbleRenderer;
 import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderedLine;
 import me.whereareiam.socialismus.module.bubbler.common.animation.type.queue.AbstractQueuedAnimation;
 import me.whereareiam.socialismus.module.bubbler.common.animation.type.queue.BubbleQueue;
-import me.whereareiam.socialismus.module.bubbler.common.renderer.ArmorStandRenderer;
 import me.whereareiam.socialismus.module.bubbler.common.renderer.BubbleRendererFactory;
 import me.whereareiam.socialismus.service.Scheduler;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -46,13 +43,8 @@ public final class StaticBubbleAnimation extends AbstractQueuedAnimation {
 		Position eyePos = sender.getEyePosition();
 
 		BubbleRenderer renderer = getRenderer();
-		List<RenderedLine> lines = new ArrayList<>();
-
-		if (renderer.supportsScaleAnimation()) {
-			spawnTextDisplayLines(bubble, group, headGap, spacing, eyePos, renderer, recipients, lines, sender);
-		} else {
-			spawnArmorStandLines(bubble, group, eyePos, recipients, lines, sender);
-		}
+		List<RenderedLine> lines = renderer.getStrategy().spawnStaticGroup(
+				bubble, group, headGap, spacing, eyePos, sender, recipients);
 
 		long delayMs = group.calculateDisplayTime() * 1_000L;
 		scheduler.schedule(
@@ -66,59 +58,5 @@ public final class StaticBubbleAnimation extends AbstractQueuedAnimation {
 						})
 						.build()
 		);
-	}
-
-	private void spawnTextDisplayLines(
-			Bubble bubble,
-			BubbleGroup group,
-			float headGap,
-			float spacing,
-			Position eyePos,
-			BubbleRenderer renderer,
-			Collection<User> recipients,
-			List<RenderedLine> lines,
-			SocialismusPlayer sender
-	) {
-		List<BubbleLine> bubbleLines = group.getLines();
-
-		for (int i = 0; i < bubbleLines.size(); i++) {
-			float yOffset = headGap + i * spacing;
-			RenderedLine line = renderer.spawnLine(bubble, bubbleLines.get(i), yOffset, eyePos);
-			renderer.sendSpawn(line, recipients);
-			lines.add(line);
-		}
-
-		int vehicleId = user(sender).getEntityId();
-		for (RenderedLine line : lines) {
-			renderer.attachAsPassenger(vehicleId, line, recipients);
-		}
-	}
-
-	private void spawnArmorStandLines(
-			Bubble bubble,
-			BubbleGroup group,
-			Position eyePos,
-			Collection<User> recipients,
-			List<RenderedLine> lines,
-			SocialismusPlayer sender
-	) {
-		ArmorStandRenderer asRenderer = rendererFactory.getArmorStandRenderer();
-		List<BubbleLine> bubbleLines = group.getLines();
-		int previousVehicle = user(sender).getEntityId();
-
-		for (int i = 0; i < bubbleLines.size(); i++) {
-			RenderedLine line;
-			if (i == 0) {
-				line = asRenderer.spawnLine(bubble, bubbleLines.get(i), 0, eyePos);
-			} else {
-				line = asRenderer.spawnLineWithSpacer(bubbleLines.get(i), eyePos);
-			}
-
-			asRenderer.sendSpawn(line, recipients);
-			asRenderer.attachAsPassenger(previousVehicle, line, recipients);
-			lines.add(line);
-
-			previousVehicle = asRenderer.getPassengerAnchorId(line);
-		}
 	}
 }

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/StaticBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/StaticBubbleAnimation.java
@@ -1,24 +1,33 @@
 package me.whereareiam.socialismus.module.bubbler.common.animation.mode.queue;
 
+import com.github.retrooper.packetevents.protocol.player.User;
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import me.whereareiam.socialismus.model.player.SocialismusPlayer;
 import me.whereareiam.socialismus.model.position.Position;
 import me.whereareiam.socialismus.model.scheduler.DelayedRunnableTask;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleGroup;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleLine;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleMessage;
-import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.PassengerPacket;
-import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.TextDisplayPacket;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.BubbleRenderer;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderedLine;
 import me.whereareiam.socialismus.module.bubbler.common.animation.type.queue.AbstractQueuedAnimation;
 import me.whereareiam.socialismus.module.bubbler.common.animation.type.queue.BubbleQueue;
+import me.whereareiam.socialismus.module.bubbler.common.renderer.ArmorStandRenderer;
+import me.whereareiam.socialismus.module.bubbler.common.renderer.BubbleRendererFactory;
 import me.whereareiam.socialismus.service.Scheduler;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
+@Singleton
 public final class StaticBubbleAnimation extends AbstractQueuedAnimation {
+
 	@Inject
-	public StaticBubbleAnimation(Scheduler scheduler) {
-		super(scheduler);
+	public StaticBubbleAnimation(Scheduler scheduler, BubbleRendererFactory rendererFactory) {
+		super(scheduler, rendererFactory);
 	}
 
 	@Override
@@ -29,24 +38,18 @@ public final class StaticBubbleAnimation extends AbstractQueuedAnimation {
 			BubbleQueue queue
 	) {
 		Bubble bubble = msg.getBubble();
-		Collection<SocialismusPlayer> recipients = msg.getRecipients();
+		Collection<User> recipients = users(msg.getRecipients());
 		float headGap = bubble.getDisplay().getHeadLineGap();
 		float spacing = bubble.getDisplay().getLineSpacing();
-
-		List<Integer> entityIds = new ArrayList<>();
 		Position eyePos = sender.getEyePosition();
 
-		for (int i = 0; i < group.getLines().size(); i++) {
-			float y = headGap + i * spacing;
-			TextDisplayPacket p = textPacket(bubble, group.getLines().get(i), y, eyePos);
-			recipients.forEach(r -> p.send(user(r)));
-			entityIds.add(p.getEntityId());
-		}
+		BubbleRenderer renderer = getRenderer();
+		List<RenderedLine> lines = new ArrayList<>();
 
-		if (!entityIds.isEmpty()) {
-			int[] arr = entityIds.stream().mapToInt(Integer::intValue).toArray();
-			PassengerPacket passenger = passengerPacket(user(sender), arr);
-			recipients.forEach(r -> passenger.send(user(r)));
+		if (renderer.supportsScaleAnimation()) {
+			spawnTextDisplayLines(bubble, group, headGap, spacing, eyePos, renderer, recipients, lines, sender);
+		} else {
+			spawnArmorStandLines(bubble, group, eyePos, recipients, lines, sender);
 		}
 
 		long delayMs = group.calculateDisplayTime() * 1_000L;
@@ -55,11 +58,65 @@ public final class StaticBubbleAnimation extends AbstractQueuedAnimation {
 						.module("bubbler")
 						.delay(delayMs)
 						.runnable(() -> {
-							recipients.forEach(r -> destroyEntities(Map.of(r, entityIds)));
+							renderer.destroy(lines, recipients);
 							queue.setProcessing(false);
 							nextGroup(sender, queue);
 						})
 						.build()
 		);
+	}
+
+	private void spawnTextDisplayLines(
+			Bubble bubble,
+			BubbleGroup group,
+			float headGap,
+			float spacing,
+			Position eyePos,
+			BubbleRenderer renderer,
+			Collection<User> recipients,
+			List<RenderedLine> lines,
+			SocialismusPlayer sender
+	) {
+		List<BubbleLine> bubbleLines = group.getLines();
+
+		for (int i = 0; i < bubbleLines.size(); i++) {
+			float yOffset = headGap + i * spacing;
+			RenderedLine line = renderer.spawnLine(bubble, bubbleLines.get(i), yOffset, eyePos);
+			renderer.sendSpawn(line, recipients);
+			lines.add(line);
+		}
+
+		int vehicleId = user(sender).getEntityId();
+		for (RenderedLine line : lines) {
+			renderer.attachAsPassenger(vehicleId, line, recipients);
+		}
+	}
+
+	private void spawnArmorStandLines(
+			Bubble bubble,
+			BubbleGroup group,
+			Position eyePos,
+			Collection<User> recipients,
+			List<RenderedLine> lines,
+			SocialismusPlayer sender
+	) {
+		ArmorStandRenderer asRenderer = rendererFactory.getArmorStandRenderer();
+		List<BubbleLine> bubbleLines = group.getLines();
+		int previousVehicle = user(sender).getEntityId();
+
+		for (int i = 0; i < bubbleLines.size(); i++) {
+			RenderedLine line;
+			if (i == 0) {
+				line = asRenderer.spawnLine(bubble, bubbleLines.get(i), 0, eyePos);
+			} else {
+				line = asRenderer.spawnLineWithSpacer(bubbleLines.get(i), eyePos);
+			}
+
+			asRenderer.sendSpawn(line, recipients);
+			asRenderer.attachAsPassenger(previousVehicle, line, recipients);
+			lines.add(line);
+
+			previousVehicle = asRenderer.getPassengerAnchorId(line);
+		}
 	}
 }

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/ContractionBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/ContractionBubbleAnimation.java
@@ -1,70 +1,33 @@
 package me.whereareiam.socialismus.module.bubbler.common.animation.mode.queue.stacked;
 
-import com.github.retrooper.packetevents.util.Vector3f;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
-import me.whereareiam.socialismus.model.player.SocialismusPlayer;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
 import me.whereareiam.socialismus.module.bubbler.api.model.config.BubblerSettings;
-import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.metadata.InterpolationMetadataPacket;
-import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.metadata.ScaleMetadataPacket;
+import me.whereareiam.socialismus.module.bubbler.common.renderer.BubbleRendererFactory;
 import me.whereareiam.socialismus.service.Scheduler;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 @Singleton
 public final class ContractionBubbleAnimation extends StackedBubbleAnimation {
-	private final Provider<BubblerSettings> settings;
 
 	@Inject
-	public ContractionBubbleAnimation(Scheduler scheduler,
-	                                  Provider<BubblerSettings> settings) {
-		super(scheduler, settings);
-		this.settings = settings;
+	public ContractionBubbleAnimation(Scheduler scheduler, BubbleRendererFactory rendererFactory, Provider<BubblerSettings> settings) {
+		super(scheduler, rendererFactory, settings);
 	}
 
 	@Override
-	protected Vector3f initialScale(Bubble b) {
-		return toVec(b.getStyle().getScale());
+	protected boolean useSpawnAnimation() {
+		return false;
 	}
 
 	@Override
-	protected void spawnAnimation(int id, Bubble b, Collection<SocialismusPlayer> rec) {
+	protected boolean useRemovalAnimation() {
+		return true;
 	}
 
 	@Override
-	protected void removalAnimation(SocialismusPlayer sender, int id, Bubble b, Collection<SocialismusPlayer> recipients, Runnable after) {
-		long durationMs = settings.get().getAnimation().getContraction().getDuration();
-		int ticks = Math.max(1, (int) Math.ceil(durationMs / (double) tickMs()));
-		float end = settings.get().getAnimation().getContraction().getEndScale();
-
-		recipients.forEach(r -> {
-			InterpolationMetadataPacket.builder()
-					.entityId(id)
-					.startDelayTicks(0)
-					.transformDurationTicks(ticks)
-					.positionRotationDurationTicks(0)
-					.build()
-					.send(user(r));
-
-			schedule(tickMs(), () -> ScaleMetadataPacket.builder()
-					.entityId(id)
-					.scale(new Vector3f(end, end, end))
-					.build()
-					.send(user(r)));
-		});
-
-		schedule(durationMs + tickMs(), () -> {
-			recipients.forEach(r -> destroyEntities(Map.of(r, List.of(id))));
-			after.run();
-		});
-	}
-
-	@Override
-	protected long extraSpawnDelayMs(Bubble b) {
+	protected long extraSpawnDelayMs(Bubble bubble) {
 		return 0;
 	}
 }

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/ContractionBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/ContractionBubbleAnimation.java
@@ -10,9 +10,12 @@ import me.whereareiam.socialismus.service.Scheduler;
 
 @Singleton
 public final class ContractionBubbleAnimation extends StackedBubbleAnimation {
-
 	@Inject
-	public ContractionBubbleAnimation(Scheduler scheduler, BubbleRendererFactory rendererFactory, Provider<BubblerSettings> settings) {
+	public ContractionBubbleAnimation(
+			Scheduler scheduler,
+			BubbleRendererFactory rendererFactory,
+			Provider<BubblerSettings> settings
+	) {
 		super(scheduler, rendererFactory, settings);
 	}
 

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/ExpansionBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/ExpansionBubbleAnimation.java
@@ -1,66 +1,33 @@
 package me.whereareiam.socialismus.module.bubbler.common.animation.mode.queue.stacked;
 
-import com.github.retrooper.packetevents.util.Vector3f;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
-import me.whereareiam.socialismus.model.player.SocialismusPlayer;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
 import me.whereareiam.socialismus.module.bubbler.api.model.config.BubblerSettings;
-import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.metadata.InterpolationMetadataPacket;
-import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.metadata.ScaleMetadataPacket;
+import me.whereareiam.socialismus.module.bubbler.common.renderer.BubbleRendererFactory;
 import me.whereareiam.socialismus.service.Scheduler;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 @Singleton
 public final class ExpansionBubbleAnimation extends StackedBubbleAnimation {
-	private final Provider<BubblerSettings> settings;
 
 	@Inject
-	public ExpansionBubbleAnimation(Scheduler scheduler, Provider<BubblerSettings> settings) {
-		super(scheduler, settings);
-		this.settings = settings;
+	public ExpansionBubbleAnimation(Scheduler scheduler, BubbleRendererFactory rendererFactory, Provider<BubblerSettings> settings) {
+		super(scheduler, rendererFactory, settings);
 	}
 
 	@Override
-	protected Vector3f initialScale(Bubble b) {
-		float s = settings.get().getAnimation().getExpansion().getStartScale();
-		return new Vector3f(s, s, s);
+	protected boolean useSpawnAnimation() {
+		return true;
 	}
 
 	@Override
-	protected void spawnAnimation(int id, Bubble b, Collection<SocialismusPlayer> recipients) {
-		long durMs = settings.get().getAnimation().getExpansion().getDuration();
-		int ticks = Math.max(1, (int) Math.ceil(durMs / (double) tickMs()));
-
-		recipients.forEach(r -> InterpolationMetadataPacket.builder()
-				.entityId(id)
-				.startDelayTicks(0)
-				.transformDurationTicks(ticks)
-				.positionRotationDurationTicks(0)
-				.build()
-				.send(user(r)));
-
-		schedule(tickMs(), () ->
-				recipients.forEach(r ->
-						ScaleMetadataPacket.builder()
-								.entityId(id)
-								.scale(toVec(b.getStyle().getScale()))
-								.build()
-								.send(user(r))));
+	protected boolean useRemovalAnimation() {
+		return false;
 	}
 
 	@Override
-	protected void removalAnimation(SocialismusPlayer sender, int id, Bubble b, Collection<SocialismusPlayer> rec, Runnable after) {
-		rec.forEach(r -> destroyEntities(Map.of(r, List.of(id))));
-		after.run();
-	}
-
-	@Override
-	protected long extraSpawnDelayMs(Bubble b) {
+	protected long extraSpawnDelayMs(Bubble bubble) {
 		return tickMs() + settings.get().getAnimation().getExpansion().getDuration();
 	}
 }

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/ExpansionBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/ExpansionBubbleAnimation.java
@@ -10,9 +10,12 @@ import me.whereareiam.socialismus.service.Scheduler;
 
 @Singleton
 public final class ExpansionBubbleAnimation extends StackedBubbleAnimation {
-
 	@Inject
-	public ExpansionBubbleAnimation(Scheduler scheduler, BubbleRendererFactory rendererFactory, Provider<BubblerSettings> settings) {
+	public ExpansionBubbleAnimation(
+			Scheduler scheduler,
+			BubbleRendererFactory rendererFactory,
+			Provider<BubblerSettings> settings
+	) {
 		super(scheduler, rendererFactory, settings);
 	}
 

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/PopoutBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/PopoutBubbleAnimation.java
@@ -1,43 +1,33 @@
 package me.whereareiam.socialismus.module.bubbler.common.animation.mode.queue.stacked;
 
-import com.github.retrooper.packetevents.util.Vector3f;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
-import me.whereareiam.socialismus.model.player.SocialismusPlayer;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
 import me.whereareiam.socialismus.module.bubbler.api.model.config.BubblerSettings;
+import me.whereareiam.socialismus.module.bubbler.common.renderer.BubbleRendererFactory;
 import me.whereareiam.socialismus.service.Scheduler;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 @Singleton
 public final class PopoutBubbleAnimation extends StackedBubbleAnimation {
 
 	@Inject
-	public PopoutBubbleAnimation(Scheduler scheduler, Provider<BubblerSettings> settings) {
-		super(scheduler, settings);
+	public PopoutBubbleAnimation(Scheduler scheduler, BubbleRendererFactory rendererFactory, Provider<BubblerSettings> settings) {
+		super(scheduler, rendererFactory, settings);
 	}
 
 	@Override
-	protected Vector3f initialScale(Bubble b) {
-		return toVec(b.getStyle().getScale());
+	protected boolean useSpawnAnimation() {
+		return false;
 	}
 
 	@Override
-	protected void spawnAnimation(int id, Bubble b, Collection<SocialismusPlayer> rec) {
+	protected boolean useRemovalAnimation() {
+		return false;
 	}
 
 	@Override
-	protected void removalAnimation(SocialismusPlayer sender, int id, Bubble b, Collection<SocialismusPlayer> recipients, Runnable after) {
-		recipients.forEach(r -> destroyEntities(Map.of(r, List.of(id))));
-		after.run();
-	}
-
-	@Override
-	protected long extraSpawnDelayMs(Bubble b) {
+	protected long extraSpawnDelayMs(Bubble bubble) {
 		return 0;
 	}
 }

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/StackedBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/StackedBubbleAnimation.java
@@ -90,10 +90,14 @@ abstract class StackedBubbleAnimation extends AbstractQueuedAnimation {
 		}
 
 		RenderedLine line = renderer.getStrategy().spawnStackedLine(bubble, lines.get(index), eyePos, renderedLines);
+		
+		// Send spawn packet first
+		renderer.sendSpawn(line, recipients);
+		
+		// THEN apply initial scale if using spawn animation (sends metadata AFTER spawn)
 		if (useSpawnAnimation()) {
 			renderer.applyInitialScale(line, bubble, recipients);
 		}
-		renderer.sendSpawn(line, recipients);
 
 		if (useSpawnAnimation()) {
 			renderer.animateSpawn(line, bubble, recipients);

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/StackedBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/StackedBubbleAnimation.java
@@ -4,6 +4,7 @@ import com.github.retrooper.packetevents.protocol.player.User;
 import com.github.retrooper.packetevents.util.Vector3f;
 import com.google.inject.Provider;
 import me.whereareiam.socialismus.model.player.SocialismusPlayer;
+import me.whereareiam.socialismus.model.position.Position;
 import me.whereareiam.socialismus.model.scheduler.DelayedRunnableTask;
 import me.whereareiam.socialismus.module.bubbler.api.model.Vector;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
@@ -11,34 +12,29 @@ import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleGroup;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleLine;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleMessage;
 import me.whereareiam.socialismus.module.bubbler.api.model.config.BubblerSettings;
-import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.PassengerPacket;
-import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.TextDisplayPacket;
-import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.metadata.TranslationMetadataPacket;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.BubbleRenderer;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderedLine;
 import me.whereareiam.socialismus.module.bubbler.common.animation.type.queue.AbstractQueuedAnimation;
 import me.whereareiam.socialismus.module.bubbler.common.animation.type.queue.BubbleQueue;
+import me.whereareiam.socialismus.module.bubbler.common.renderer.ArmorStandRenderer;
+import me.whereareiam.socialismus.module.bubbler.common.renderer.BubbleRendererFactory;
 import me.whereareiam.socialismus.service.Scheduler;
 
 import java.util.*;
 
 abstract class StackedBubbleAnimation extends AbstractQueuedAnimation {
-	private static final long TICK_MS = 50L;
+	protected static final long TICK_MS = 50L;
 
-	private final Provider<BubblerSettings> settings;
+	protected final Provider<BubblerSettings> settings;
 
-	protected StackedBubbleAnimation(Scheduler scheduler, Provider<BubblerSettings> settings) {
-		super(scheduler);
+	protected StackedBubbleAnimation(Scheduler scheduler, BubbleRendererFactory rendererFactory, Provider<BubblerSettings> settings) {
+		super(scheduler, rendererFactory);
 		this.settings = settings;
 	}
 
-	protected abstract Vector3f initialScale(Bubble bubble);
+	protected abstract boolean useSpawnAnimation();
 
-	protected abstract void spawnAnimation(int entityId, Bubble bubble, Collection<SocialismusPlayer> recipients);
-
-	protected abstract void removalAnimation(SocialismusPlayer sender,
-	                                         int entityId,
-	                                         Bubble bubble,
-	                                         Collection<SocialismusPlayer> recipients,
-	                                         Runnable after);
+	protected abstract boolean useRemovalAnimation();
 
 	protected abstract long extraSpawnDelayMs(Bubble bubble);
 
@@ -46,93 +42,168 @@ abstract class StackedBubbleAnimation extends AbstractQueuedAnimation {
 	protected final void playGroup(SocialismusPlayer sender, BubbleMessage msg, BubbleGroup group, BubbleQueue queue) {
 		List<BubbleLine> lines = new ArrayList<>(group.getLines());
 		Collections.reverse(lines);
-		step(sender, msg, lines, 0, new HashMap<>(), queue);
+
+		BubbleRenderer renderer = getRenderer();
+		if (renderer.supportsScaleAnimation()) {
+			stepTextDisplay(sender, msg, lines, 0, new ArrayList<>(), queue);
+		} else {
+			stepArmorStand(sender, msg, lines, 0, new ArrayList<>(), queue);
+		}
 	}
 
-	private void step(
+	private void stepTextDisplay(
 			SocialismusPlayer sender,
 			BubbleMessage msg,
 			List<BubbleLine> lines,
 			int index,
-			Map<SocialismusPlayer, List<Integer>> entities,
+			List<RenderedLine> renderedLines,
 			BubbleQueue queue
 	) {
 		Bubble bubble = msg.getBubble();
 		float headGap = bubble.getDisplay().getHeadLineGap();
 		float spacing = bubble.getDisplay().getLineSpacing();
 		int maxLines = bubble.getDisplay().getMaxLinesCount();
-
-		List<Integer> ids = entities.computeIfAbsent(sender, $ -> new ArrayList<>());
+		Position eyePos = sender.getEyePosition();
+		Collection<User> recipients = users(msg.getRecipients());
+		BubbleRenderer renderer = getRenderer();
 
 		if (index >= lines.size()) {
-			if (ids.isEmpty()) {
+			if (renderedLines.isEmpty()) {
 				queue.setProcessing(false);
 				nextGroup(sender, queue);
 				return;
 			}
-			int eid = ids.get(0);
-			removalAnimation(sender, eid, bubble, msg.getRecipients(), () -> {
-				ids.remove(Integer.valueOf(eid));
-				updateTranslations(ids, headGap, spacing, msg.getRecipients());
-				resendPassengers(sender, ids, msg.getRecipients());
+
+			RenderedLine toRemove = renderedLines.get(0);
+			if (useRemovalAnimation()) {
+				renderer.animateRemoval(toRemove, bubble, recipients, () -> {
+					renderedLines.remove(0);
+					updateTextDisplayPositions(renderedLines, headGap, spacing, recipients, renderer);
+					reattachAllAsPassengers(sender, renderedLines, recipients, renderer);
+					schedule(settings.get().getAnimation().getPopoutDelay(),
+							() -> stepTextDisplay(sender, msg, lines, index, renderedLines, queue));
+				});
+			} else {
+				renderer.destroy(toRemove, recipients);
+				renderedLines.remove(0);
+				updateTextDisplayPositions(renderedLines, headGap, spacing, recipients, renderer);
+				reattachAllAsPassengers(sender, renderedLines, recipients, renderer);
 				schedule(settings.get().getAnimation().getPopoutDelay(),
-						() -> step(sender, msg, lines, index, entities, queue));
-			});
+						() -> stepTextDisplay(sender, msg, lines, index, renderedLines, queue));
+			}
 			return;
 		}
 
-		TextDisplayPacket spawn = textPacket(bubble, lines.get(index), headGap, sender.getEyePosition())
-				.toBuilder()
-				.scale(initialScale(bubble))
-				.build();
+		RenderedLine line = renderer.spawnLine(bubble, lines.get(index), headGap, eyePos);
+		if (useSpawnAnimation()) {
+			renderer.applyInitialScale(line, bubble, recipients);
+		}
+		renderer.sendSpawn(line, recipients);
 
-		msg.getRecipients().forEach(r -> {
-			User u = user(r);
-			spawn.send(u);
-			spawnAnimation(spawn.getEntityId(), bubble, List.of(r));
-		});
-
-		ids.add(spawn.getEntityId());
-		updateTranslations(ids, headGap, spacing, msg.getRecipients());
-
-		if (ids.size() > maxLines) {
-			int overflow = ids.get(0);
-			removalAnimation(sender, overflow, bubble, msg.getRecipients(), () -> {
-				ids.remove(Integer.valueOf(overflow));
-				updateTranslations(ids, headGap, spacing, msg.getRecipients());
-				resendPassengers(sender, ids, msg.getRecipients());
-			});
+		if (useSpawnAnimation()) {
+			renderer.animateSpawn(line, bubble, recipients);
 		}
 
-		resendPassengers(sender, ids, msg.getRecipients());
+		renderedLines.add(line);
+		updateTextDisplayPositions(renderedLines, headGap, spacing, recipients, renderer);
 
-		long readMs = lines.get(index).getDisplayTime()
-				* settings.get().getAnimation().getPopoutDelay();
+		if (renderedLines.size() > maxLines) {
+			RenderedLine overflow = renderedLines.get(0);
+			if (useRemovalAnimation()) {
+				renderer.animateRemoval(overflow, bubble, recipients, () -> {
+					renderedLines.remove(0);
+					updateTextDisplayPositions(renderedLines, headGap, spacing, recipients, renderer);
+					reattachAllAsPassengers(sender, renderedLines, recipients, renderer);
+				});
+			} else {
+				renderer.destroy(overflow, recipients);
+				renderedLines.remove(0);
+				updateTextDisplayPositions(renderedLines, headGap, spacing, recipients, renderer);
+			}
+		}
+
+		reattachAllAsPassengers(sender, renderedLines, recipients, renderer);
+
+		long readMs = lines.get(index).getDisplayTime() * settings.get().getAnimation().getPopoutDelay();
 		long nextMs = extraSpawnDelayMs(bubble) + readMs;
-		schedule(nextMs, () ->
-				step(sender, msg, lines, index + 1, entities, queue));
+		schedule(nextMs, () -> stepTextDisplay(sender, msg, lines, index + 1, renderedLines, queue));
 	}
 
-	private void updateTranslations(List<Integer> ids, float headGap, float spacing, Collection<SocialismusPlayer> rec) {
-		for (int i = ids.size() - 1, level = 0; i >= 0; i--, level++) {
-			Vector3f t = new Vector3f(0F, headGap + level * spacing, 0F);
-			int id = ids.get(i);
-			rec.forEach(r -> TranslationMetadataPacket.builder()
-					.entityId(id)
-					.translation(t)
-					.build()
-					.send(user(r)));
+	private void stepArmorStand(
+			SocialismusPlayer sender,
+			BubbleMessage msg,
+			List<BubbleLine> lines,
+			int index,
+			List<RenderedLine> renderedLines,
+			BubbleQueue queue
+	) {
+		Bubble bubble = msg.getBubble();
+		int maxLines = bubble.getDisplay().getMaxLinesCount();
+		Position eyePos = sender.getEyePosition();
+		Collection<User> recipients = users(msg.getRecipients());
+		ArmorStandRenderer renderer = rendererFactory.getArmorStandRenderer();
+
+		if (index >= lines.size()) {
+			if (renderedLines.isEmpty()) {
+				queue.setProcessing(false);
+				nextGroup(sender, queue);
+				return;
+			}
+
+			RenderedLine toRemove = renderedLines.get(0);
+			renderer.destroy(toRemove, recipients);
+			renderedLines.remove(0);
+
+			schedule(settings.get().getAnimation().getPopoutDelay(),
+					() -> stepArmorStand(sender, msg, lines, index, renderedLines, queue));
+			return;
+		}
+
+		RenderedLine line = renderer.spawnLineWithSpacer(lines.get(index), eyePos);
+		renderer.sendSpawn(line, recipients);
+		renderer.attachArmorStandOnly(user(sender).getEntityId(), line, recipients);
+
+		if (!renderedLines.isEmpty()) {
+			RenderedLine previousBottom = renderedLines.get(renderedLines.size() - 1);
+			renderer.rechainPassenger(renderer.getPassengerAnchorId(line), previousBottom, recipients);
+		}
+
+		renderedLines.add(line);
+
+		if (renderedLines.size() > maxLines) {
+			RenderedLine overflow = renderedLines.get(0);
+			renderer.destroy(overflow, recipients);
+			renderedLines.remove(0);
+		}
+
+		long readMs = lines.get(index).getDisplayTime() * settings.get().getAnimation().getPopoutDelay();
+		long nextMs = extraSpawnDelayMs(bubble) + readMs;
+		schedule(nextMs, () -> stepArmorStand(sender, msg, lines, index + 1, renderedLines, queue));
+	}
+
+	private void updateTextDisplayPositions(
+			List<RenderedLine> lines,
+			float headGap,
+			float spacing,
+			Collection<User> recipients,
+			BubbleRenderer renderer
+	) {
+		for (int i = lines.size() - 1, level = 0; i >= 0; i--, level++) {
+			float yOffset = headGap + level * spacing;
+			renderer.updatePosition(lines.get(i), yOffset, null, recipients);
 		}
 	}
 
-	private void resendPassengers(SocialismusPlayer sender, List<Integer> ids, Collection<SocialismusPlayer> rec) {
-		int[] arr = ids.stream().mapToInt(Integer::intValue).toArray();
-		PassengerPacket p = passengerPacket(user(sender), arr);
-		rec.forEach(r -> p.send(user(r)));
-	}
-
-	protected Vector3f toVec(Vector v) {
-		return new Vector3f(v.getX(), v.getY(), v.getZ());
+	private void reattachAllAsPassengers(
+			SocialismusPlayer sender,
+			List<RenderedLine> lines,
+			Collection<User> recipients,
+			BubbleRenderer renderer
+	) {
+		int vehicleId = user(sender).getEntityId();
+		for (RenderedLine line : lines) {
+			renderer.attachAsPassenger(vehicleId, line, recipients);
+		}
 	}
 
 	protected void schedule(long delayMs, Runnable r) {

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/StackedBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/StackedBubbleAnimation.java
@@ -1,12 +1,10 @@
 package me.whereareiam.socialismus.module.bubbler.common.animation.mode.queue.stacked;
 
 import com.github.retrooper.packetevents.protocol.player.User;
-import com.github.retrooper.packetevents.util.Vector3f;
 import com.google.inject.Provider;
 import me.whereareiam.socialismus.model.player.SocialismusPlayer;
 import me.whereareiam.socialismus.model.position.Position;
 import me.whereareiam.socialismus.model.scheduler.DelayedRunnableTask;
-import me.whereareiam.socialismus.module.bubbler.api.model.Vector;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleGroup;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleLine;
@@ -27,7 +25,11 @@ abstract class StackedBubbleAnimation extends AbstractQueuedAnimation {
 
 	protected final Provider<BubblerSettings> settings;
 
-	protected StackedBubbleAnimation(Scheduler scheduler, BubbleRendererFactory rendererFactory, Provider<BubblerSettings> settings) {
+	protected StackedBubbleAnimation(
+			Scheduler scheduler,
+			BubbleRendererFactory rendererFactory,
+			Provider<BubblerSettings> settings
+	) {
 		super(scheduler, rendererFactory);
 		this.settings = settings;
 	}

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/StackedBubbleAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/mode/queue/stacked/StackedBubbleAnimation.java
@@ -14,8 +14,8 @@ import me.whereareiam.socialismus.module.bubbler.api.renderer.BubbleRenderer;
 import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderedLine;
 import me.whereareiam.socialismus.module.bubbler.common.animation.type.queue.AbstractQueuedAnimation;
 import me.whereareiam.socialismus.module.bubbler.common.animation.type.queue.BubbleQueue;
-import me.whereareiam.socialismus.module.bubbler.common.renderer.ArmorStandRenderer;
 import me.whereareiam.socialismus.module.bubbler.common.renderer.BubbleRendererFactory;
+import me.whereareiam.socialismus.module.bubbler.common.renderer.strategy.TextDisplayRenderStrategy;
 import me.whereareiam.socialismus.service.Scheduler;
 
 import java.util.*;
@@ -45,15 +45,10 @@ abstract class StackedBubbleAnimation extends AbstractQueuedAnimation {
 		List<BubbleLine> lines = new ArrayList<>(group.getLines());
 		Collections.reverse(lines);
 
-		BubbleRenderer renderer = getRenderer();
-		if (renderer.supportsScaleAnimation()) {
-			stepTextDisplay(sender, msg, lines, 0, new ArrayList<>(), queue);
-		} else {
-			stepArmorStand(sender, msg, lines, 0, new ArrayList<>(), queue);
-		}
+		step(sender, msg, lines, 0, new ArrayList<>(), queue);
 	}
 
-	private void stepTextDisplay(
+	private void step(
 			SocialismusPlayer sender,
 			BubbleMessage msg,
 			List<BubbleLine> lines,
@@ -80,23 +75,21 @@ abstract class StackedBubbleAnimation extends AbstractQueuedAnimation {
 			if (useRemovalAnimation()) {
 				renderer.animateRemoval(toRemove, bubble, recipients, () -> {
 					renderedLines.remove(0);
-					updateTextDisplayPositions(renderedLines, headGap, spacing, recipients, renderer);
-					reattachAllAsPassengers(sender, renderedLines, recipients, renderer);
+					renderer.getStrategy().updateStackedPositions(sender, renderedLines, headGap, spacing, recipients);
 					schedule(settings.get().getAnimation().getPopoutDelay(),
-							() -> stepTextDisplay(sender, msg, lines, index, renderedLines, queue));
+							() -> step(sender, msg, lines, index, renderedLines, queue));
 				});
 			} else {
 				renderer.destroy(toRemove, recipients);
 				renderedLines.remove(0);
-				updateTextDisplayPositions(renderedLines, headGap, spacing, recipients, renderer);
-				reattachAllAsPassengers(sender, renderedLines, recipients, renderer);
+				renderer.getStrategy().updateStackedPositions(sender, renderedLines, headGap, spacing, recipients);
 				schedule(settings.get().getAnimation().getPopoutDelay(),
-						() -> stepTextDisplay(sender, msg, lines, index, renderedLines, queue));
+						() -> step(sender, msg, lines, index, renderedLines, queue));
 			}
 			return;
 		}
 
-		RenderedLine line = renderer.spawnLine(bubble, lines.get(index), headGap, eyePos);
+		RenderedLine line = renderer.getStrategy().spawnStackedLine(bubble, lines.get(index), eyePos, renderedLines);
 		if (useSpawnAnimation()) {
 			renderer.applyInitialScale(line, bubble, recipients);
 		}
@@ -106,106 +99,34 @@ abstract class StackedBubbleAnimation extends AbstractQueuedAnimation {
 			renderer.animateSpawn(line, bubble, recipients);
 		}
 
+		// Attach the new line and reposition existing lines immediately
+		renderer.getStrategy().attachNewStackedLine(sender, line, renderedLines, recipients);
+		
 		renderedLines.add(line);
-		updateTextDisplayPositions(renderedLines, headGap, spacing, recipients, renderer);
+		
+		// For text displays, we need to update positions after adding to the list
+		// For armor stands, attachNewStackedLine already set up the chain correctly
+		if (renderer.getStrategy() instanceof TextDisplayRenderStrategy) {
+			renderer.getStrategy().updateStackedPositions(sender, renderedLines, headGap, spacing, recipients);
+		}
 
 		if (renderedLines.size() > maxLines) {
 			RenderedLine overflow = renderedLines.get(0);
 			if (useRemovalAnimation()) {
 				renderer.animateRemoval(overflow, bubble, recipients, () -> {
 					renderedLines.remove(0);
-					updateTextDisplayPositions(renderedLines, headGap, spacing, recipients, renderer);
-					reattachAllAsPassengers(sender, renderedLines, recipients, renderer);
+					renderer.getStrategy().updateStackedPositions(sender, renderedLines, headGap, spacing, recipients);
 				});
 			} else {
 				renderer.destroy(overflow, recipients);
 				renderedLines.remove(0);
-				updateTextDisplayPositions(renderedLines, headGap, spacing, recipients, renderer);
+				renderer.getStrategy().updateStackedPositions(sender, renderedLines, headGap, spacing, recipients);
 			}
-		}
-
-		reattachAllAsPassengers(sender, renderedLines, recipients, renderer);
-
-		long readMs = lines.get(index).getDisplayTime() * settings.get().getAnimation().getPopoutDelay();
-		long nextMs = extraSpawnDelayMs(bubble) + readMs;
-		schedule(nextMs, () -> stepTextDisplay(sender, msg, lines, index + 1, renderedLines, queue));
-	}
-
-	private void stepArmorStand(
-			SocialismusPlayer sender,
-			BubbleMessage msg,
-			List<BubbleLine> lines,
-			int index,
-			List<RenderedLine> renderedLines,
-			BubbleQueue queue
-	) {
-		Bubble bubble = msg.getBubble();
-		int maxLines = bubble.getDisplay().getMaxLinesCount();
-		Position eyePos = sender.getEyePosition();
-		Collection<User> recipients = users(msg.getRecipients());
-		ArmorStandRenderer renderer = rendererFactory.getArmorStandRenderer();
-
-		if (index >= lines.size()) {
-			if (renderedLines.isEmpty()) {
-				queue.setProcessing(false);
-				nextGroup(sender, queue);
-				return;
-			}
-
-			RenderedLine toRemove = renderedLines.get(0);
-			renderer.destroy(toRemove, recipients);
-			renderedLines.remove(0);
-
-			schedule(settings.get().getAnimation().getPopoutDelay(),
-					() -> stepArmorStand(sender, msg, lines, index, renderedLines, queue));
-			return;
-		}
-
-		RenderedLine line = renderer.spawnLineWithSpacer(lines.get(index), eyePos);
-		renderer.sendSpawn(line, recipients);
-		renderer.attachArmorStandOnly(user(sender).getEntityId(), line, recipients);
-
-		if (!renderedLines.isEmpty()) {
-			RenderedLine previousBottom = renderedLines.get(renderedLines.size() - 1);
-			renderer.rechainPassenger(renderer.getPassengerAnchorId(line), previousBottom, recipients);
-		}
-
-		renderedLines.add(line);
-
-		if (renderedLines.size() > maxLines) {
-			RenderedLine overflow = renderedLines.get(0);
-			renderer.destroy(overflow, recipients);
-			renderedLines.remove(0);
 		}
 
 		long readMs = lines.get(index).getDisplayTime() * settings.get().getAnimation().getPopoutDelay();
 		long nextMs = extraSpawnDelayMs(bubble) + readMs;
-		schedule(nextMs, () -> stepArmorStand(sender, msg, lines, index + 1, renderedLines, queue));
-	}
-
-	private void updateTextDisplayPositions(
-			List<RenderedLine> lines,
-			float headGap,
-			float spacing,
-			Collection<User> recipients,
-			BubbleRenderer renderer
-	) {
-		for (int i = lines.size() - 1, level = 0; i >= 0; i--, level++) {
-			float yOffset = headGap + level * spacing;
-			renderer.updatePosition(lines.get(i), yOffset, null, recipients);
-		}
-	}
-
-	private void reattachAllAsPassengers(
-			SocialismusPlayer sender,
-			List<RenderedLine> lines,
-			Collection<User> recipients,
-			BubbleRenderer renderer
-	) {
-		int vehicleId = user(sender).getEntityId();
-		for (RenderedLine line : lines) {
-			renderer.attachAsPassenger(vehicleId, line, recipients);
-		}
+		schedule(nextMs, () -> step(sender, msg, lines, index + 1, renderedLines, queue));
 	}
 
 	protected void schedule(long delayMs, Runnable r) {

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/type/queue/AbstractQueuedAnimation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/animation/type/queue/AbstractQueuedAnimation.java
@@ -2,27 +2,29 @@ package me.whereareiam.socialismus.module.bubbler.common.animation.type.queue;
 
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.protocol.player.User;
-import com.github.retrooper.packetevents.util.Vector3f;
 import lombok.NonNull;
 import me.whereareiam.socialismus.model.player.SocialismusPlayer;
-import me.whereareiam.socialismus.model.position.Position;
-import me.whereareiam.socialismus.module.bubbler.api.model.bubble.*;
-import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.PassengerPacket;
-import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.DestroyEntitiesPacket;
-import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.TextDisplayPacket;
-import me.whereareiam.socialismus.module.bubbler.common.util.PacketUtil;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleAnimation;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleGroup;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleMessage;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.BubbleRenderer;
+import me.whereareiam.socialismus.module.bubbler.common.renderer.BubbleRendererFactory;
 import me.whereareiam.socialismus.service.Scheduler;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 public abstract class AbstractQueuedAnimation extends BubbleAnimation {
 
 	private final Map<SocialismusPlayer, BubbleQueue> queues = new ConcurrentHashMap<>();
+	protected final BubbleRendererFactory rendererFactory;
 
-	protected AbstractQueuedAnimation(Scheduler scheduler) {
+	protected AbstractQueuedAnimation(Scheduler scheduler, BubbleRendererFactory rendererFactory) {
 		super(scheduler);
+		this.rendererFactory = rendererFactory;
 	}
 
 	@Override
@@ -44,13 +46,6 @@ public abstract class AbstractQueuedAnimation extends BubbleAnimation {
 		);
 	}
 
-	/**
-	 * Sub-classes implement their visual behaviour here.
-	 * <p>
-	 * The call **must** end with {@code queue.setProcessing(false)} and then
-	 * either call {@link #nextGroup(SocialismusPlayer, BubbleQueue)} again or remove
-	 * the just-finished message if all groups are done.
-	 */
 	protected abstract void playGroup(
 			SocialismusPlayer sender,
 			BubbleMessage message,
@@ -58,45 +53,19 @@ public abstract class AbstractQueuedAnimation extends BubbleAnimation {
 			BubbleQueue queue
 	);
 
-	protected TextDisplayPacket textPacket(
-			Bubble bubble, BubbleLine line, float yOffset, Position eyePos
-	) {
-		Bubble.Style s = bubble.getStyle();
-		return TextDisplayPacket.builder()
-				.position(PacketUtil.toVector3d(eyePos))
-				.text(line.getContent())
-				.type(s.getDisplay())
-				.backgroundColor(s.getBackground().getColor())
-				.transparency(s.getBackground().getTransparency())
-				.alignment(s.getText().getAlignment())
-				.hasShadow(s.getText().isShadow())
-				.isSeeThrough(s.isSeeThrough())
-				.translation(new Vector3f(0, yOffset, 0))
-				.build();
+	protected BubbleRenderer getRenderer() {
+		return rendererFactory.getRenderer();
 	}
 
-	protected PassengerPacket passengerPacket(User user, int[] entityIds) {
-		return PassengerPacket.builder()
-				.vehicleId(user.getEntityId())
-				.passengerIds(entityIds)
-				.build();
-	}
-
-	protected void destroyEntities(Map<SocialismusPlayer, List<Integer>> map) {
-		map.forEach((player, ids) -> {
-			User user = PacketEvents.getAPI()
-					.getPlayerManager()
-					.getUser(player.getAudience());
-			DestroyEntitiesPacket.builder()
-					.entityIds(ids.stream().mapToInt(Integer::intValue).toArray())
-					.build()
-					.send(user);
-		});
-	}
-
-	protected User user(SocialismusPlayer dummy) {
+	protected User user(SocialismusPlayer player) {
 		return PacketEvents.getAPI()
 				.getPlayerManager()
-				.getUser(dummy.getAudience());
+				.getUser(player.getAudience());
+	}
+
+	protected Collection<User> users(Collection<SocialismusPlayer> players) {
+		return players.stream()
+				.map(this::user)
+				.collect(Collectors.toList());
 	}
 }

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/config/ConfiguraBootstrap.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/config/ConfiguraBootstrap.java
@@ -1,0 +1,23 @@
+package me.whereareiam.socialismus.module.bubbler.common.config;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.whereareiam.configura.Config;
+import me.whereareiam.socialismus.model.requirement.Requirement;
+import me.whereareiam.socialismus.module.bubbler.api.model.requirement.ActivatorRequirement;
+
+/**
+ * Registers Bubbler-specific polymorphic types with Configura.
+ * This allows Bubbler's custom requirement types to be properly
+ * deserialized from configuration files without modifying Socialismus core.
+ */
+@Singleton
+public class ConfiguraBootstrap {
+	@Inject
+	public ConfiguraBootstrap() {
+		// Register Bubbler's polymorphic requirement types
+		Config.registerPolymorphic(Requirement.class)
+				.inferByField("activators", ActivatorRequirement.class)
+				.build();
+	}
+}

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/config/template/BubblerSettingsTemplate.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/config/template/BubblerSettingsTemplate.java
@@ -9,7 +9,6 @@ import me.whereareiam.socialismus.module.bubbler.api.type.BubbleType;
 public class BubblerSettingsTemplate implements TemplateProvider<BubblerSettings> {
 	@Override
 	public BubblerSettings supply(BubblerSettings config) {
-		// Default values
 		config.setBubbleType(BubbleType.TEXT_DISPLAY);
 		config.setMinRecipients(1);
 		config.setMaxQueueSize(30);

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/config/template/BubblesConfigTemplate.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/config/template/BubblesConfigTemplate.java
@@ -2,9 +2,9 @@ package me.whereareiam.socialismus.module.bubbler.common.config.template;
 
 import com.google.inject.Singleton;
 import me.whereareiam.configura.TemplateProvider;
+import me.whereareiam.socialismus.Constants;
 import me.whereareiam.socialismus.model.requirement.RequirementGroup;
 import me.whereareiam.socialismus.model.requirement.type.ChatRequirement;
-import me.whereareiam.socialismus.model.requirement.type.PlaceholderRequirement;
 import me.whereareiam.socialismus.module.bubbler.api.model.Vector;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleTransition;
@@ -16,7 +16,6 @@ import me.whereareiam.socialismus.module.bubbler.common.config.dynamic.BubblesCo
 import me.whereareiam.socialismus.type.chat.Participants;
 import me.whereareiam.socialismus.type.requirement.RequirementConditionType;
 import me.whereareiam.socialismus.type.requirement.RequirementOperatorType;
-import me.whereareiam.socialismus.type.requirement.RequirementType;
 
 import java.util.List;
 import java.util.Map;
@@ -69,8 +68,9 @@ public class BubblesConfigTemplate implements TemplateProvider<BubblesConfig> {
 				)).requirements(Map.of(
 						Participants.SENDER, RequirementGroup.builder()
 								.operator(RequirementOperatorType.OR)
-								.groups(Map.of(
-										RequirementType.CHAT, ChatRequirement.builder()
+								.groups(RequirementGroup.of(
+										Constants.Requirements.CHAT,
+										ChatRequirement.builder()
 												.condition(RequirementConditionType.CONTAINS)
 												.expected("true")
 												.chatIdentifiers(List.of("null", "fallback", "local"))

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/listener/ChatBroadcastListener.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/listener/ChatBroadcastListener.java
@@ -9,6 +9,7 @@ import me.whereareiam.socialismus.event.base.SocialisticEvent;
 import me.whereareiam.socialismus.event.chat.ChatBroadcastEvent;
 import me.whereareiam.socialismus.module.bubbler.api.BubbleCoordinationService;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleMessage;
+import me.whereareiam.socialismus.module.bubbler.api.type.ActivatorType;
 
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = {@Inject})
@@ -23,6 +24,7 @@ public class ChatBroadcastListener implements EventListener {
 				.sender(event.getChatMessage().getSender())
 				.recipients(event.getChatMessage().getRecipients())
 				.content(event.getChatMessage().getContent())
+				.activatorType(ActivatorType.CHAT)
 				.build()
 		);
 	}

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/ArmorStandRenderedLine.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/ArmorStandRenderedLine.java
@@ -1,0 +1,47 @@
+package me.whereareiam.socialismus.module.bubbler.common.renderer;
+
+import lombok.Getter;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.AreaEffectCloudPacket;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.living.ArmorStandPacket;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderedLine;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ArmorStandRenderedLine implements RenderedLine {
+	private final ArmorStandPacket armorStandPacket;
+	private final AreaEffectCloudPacket spacerPacket;
+
+	public ArmorStandRenderedLine(ArmorStandPacket armorStandPacket, AreaEffectCloudPacket spacerPacket) {
+		this.armorStandPacket = armorStandPacket;
+		this.spacerPacket = spacerPacket;
+	}
+
+	public ArmorStandRenderedLine(ArmorStandPacket armorStandPacket) {
+		this(armorStandPacket, null);
+	}
+
+	public boolean hasSpacer() {
+		return spacerPacket != null;
+	}
+
+	@Override
+	public List<Integer> getAllEntityIds() {
+		List<Integer> ids = new ArrayList<>();
+		ids.add(armorStandPacket.getEntityId());
+		if (spacerPacket != null) {
+			ids.add(spacerPacket.getEntityId());
+		}
+		return ids;
+	}
+
+	@Override
+	public int getPrimaryEntityId() {
+		return armorStandPacket.getEntityId();
+	}
+
+	public int getSpacerId() {
+		return spacerPacket != null ? spacerPacket.getEntityId() : -1;
+	}
+}

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/ArmorStandRenderer.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/ArmorStandRenderer.java
@@ -12,7 +12,9 @@ import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.Ar
 import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.DestroyEntitiesPacket;
 import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.living.ArmorStandPacket;
 import me.whereareiam.socialismus.module.bubbler.api.renderer.BubbleRenderer;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderStrategy;
 import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderedLine;
+import me.whereareiam.socialismus.module.bubbler.common.renderer.strategy.ArmorStandRenderStrategy;
 import me.whereareiam.socialismus.module.bubbler.common.util.PacketUtil;
 
 import java.util.Collection;
@@ -20,9 +22,11 @@ import java.util.List;
 
 @Singleton
 public class ArmorStandRenderer implements BubbleRenderer {
+	private final RenderStrategy strategy;
 
 	@Inject
 	public ArmorStandRenderer() {
+		this.strategy = new ArmorStandRenderStrategy(this);
 	}
 
 	@Override
@@ -117,11 +121,6 @@ public class ArmorStandRenderer implements BubbleRenderer {
 	}
 
 	@Override
-	public boolean supportsScaleAnimation() {
-		return false;
-	}
-
-	@Override
 	public void applyInitialScale(RenderedLine line, Bubble bubble, Collection<User> recipients) {
 		// ArmorStand doesn't support scale animation
 	}
@@ -144,6 +143,41 @@ public class ArmorStandRenderer implements BubbleRenderer {
 		return line.getPrimaryEntityId();
 	}
 
+	/**
+	 * Gets the bottom anchor ID where older lines should attach.
+	 * For lines with spacers, this is the spacer ID (so spacer pushes old lines upward).
+	 * For lines without spacers, this is the armor stand ID.
+	 */
+	public int getBottomAnchorId(RenderedLine line) {
+		ArmorStandRenderedLine asLine = (ArmorStandRenderedLine) line;
+		return asLine.hasSpacer() ? asLine.getSpacerId() : asLine.getPrimaryEntityId();
+	}
+
+	@Override
+	public RenderStrategy getStrategy() {
+		return strategy;
+	}
+
+	// Public methods used by ArmorStandRenderStrategy
+	
+	/**
+	 * Reattaches a line (with its spacer if present) to a vehicle.
+	 * 
+	 * <p>If the line has a spacer, builds chain upward:
+	 * <ol>
+	 *   <li>Attaches spacer to vehicle (as passenger, appears above vehicle)</li>
+	 *   <li>Attaches armor stand to spacer (as passenger, appears above spacer)</li>
+	 * </ol>
+	 * 
+	 * <p>If the line has no spacer:
+	 * <ol>
+	 *   <li>Attaches armor stand directly to vehicle</li>
+	 * </ol>
+	 * 
+	 * @param vehicleId the entity ID to attach to
+	 * @param line the line to attach
+	 * @param recipients packet recipients
+	 */
 	public void rechainPassenger(int vehicleId, RenderedLine line, Collection<User> recipients) {
 		ArmorStandRenderedLine asLine = (ArmorStandRenderedLine) line;
 
@@ -163,6 +197,20 @@ public class ArmorStandRenderer implements BubbleRenderer {
 		}
 	}
 
+	/**
+	 * Attaches ONLY the armor stand entity to a vehicle, ignoring any spacer.
+	 * 
+	 * <p>Used for attaching the newest line directly to the player to keep it near head.
+	 * Even if the line has a spacer, this method skips it and attaches only the armor stand.
+	 * 
+	 * <p><b>Note:</b> If the line has a spacer, the spacer must be manually attached separately
+	 * (typically above the armor stand as a passenger) to maintain the chain structure and push
+	 * older lines higher up.
+	 * 
+	 * @param vehicleId the entity ID to attach to (typically player)
+	 * @param renderedLine the line whose armor stand should be attached
+	 * @param recipients packet recipients
+	 */
 	public void attachArmorStandOnly(int vehicleId, RenderedLine renderedLine, Collection<User> recipients) {
 		ArmorStandRenderedLine line = (ArmorStandRenderedLine) renderedLine;
 

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/ArmorStandRenderer.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/ArmorStandRenderer.java
@@ -1,0 +1,175 @@
+package me.whereareiam.socialismus.module.bubbler.common.renderer;
+
+import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.util.Vector3d;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.whereareiam.socialismus.model.position.Position;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleLine;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.PassengerPacket;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.AreaEffectCloudPacket;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.DestroyEntitiesPacket;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.living.ArmorStandPacket;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.BubbleRenderer;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderedLine;
+import me.whereareiam.socialismus.module.bubbler.common.util.PacketUtil;
+
+import java.util.Collection;
+import java.util.List;
+
+@Singleton
+public class ArmorStandRenderer implements BubbleRenderer {
+
+	@Inject
+	public ArmorStandRenderer() {
+	}
+
+	@Override
+	public RenderedLine spawnLine(Bubble bubble, BubbleLine line, float yOffset, Position eyePos) {
+		Vector3d pos = PacketUtil.toVector3d(eyePos);
+
+		ArmorStandPacket armorStand = ArmorStandPacket.builder()
+				.position(new Vector3d(pos.getX(), pos.getY() + yOffset, pos.getZ()))
+				.customName(line.getContent())
+				.noGravity(true)
+				.build();
+
+		return new ArmorStandRenderedLine(armorStand);
+	}
+
+	public RenderedLine spawnLineWithSpacer(BubbleLine line, Position eyePos) {
+		Vector3d pos = PacketUtil.toVector3d(eyePos);
+
+		AreaEffectCloudPacket spacer = AreaEffectCloudPacket.builder()
+				.position(pos)
+				.radius(0)
+				.noGravity(true)
+				.build();
+
+		ArmorStandPacket armorStand = ArmorStandPacket.builder()
+				.position(pos)
+				.customName(line.getContent())
+				.noGravity(true)
+				.build();
+
+		return new ArmorStandRenderedLine(armorStand, spacer);
+	}
+
+	@Override
+	public void sendSpawn(RenderedLine renderedLine, Collection<User> recipients) {
+		ArmorStandRenderedLine line = (ArmorStandRenderedLine) renderedLine;
+
+		if (line.hasSpacer()) {
+			recipients.forEach(r -> line.getSpacerPacket().send(r));
+		}
+		recipients.forEach(r -> line.getArmorStandPacket().send(r));
+	}
+
+	@Override
+	public void attachAsPassenger(int vehicleId, RenderedLine renderedLine, Collection<User> recipients) {
+		ArmorStandRenderedLine line = (ArmorStandRenderedLine) renderedLine;
+
+		if (line.hasSpacer()) {
+			PassengerPacket spacerPassenger = PassengerPacket.builder()
+					.vehicleId(vehicleId)
+					.passengerIds(new int[]{line.getSpacerId()})
+					.build();
+			recipients.forEach(spacerPassenger::send);
+
+			PassengerPacket armorStandPassenger = PassengerPacket.builder()
+					.vehicleId(line.getSpacerId())
+					.passengerIds(new int[]{line.getPrimaryEntityId()})
+					.build();
+			recipients.forEach(armorStandPassenger::send);
+		} else {
+			PassengerPacket passenger = PassengerPacket.builder()
+					.vehicleId(vehicleId)
+					.passengerIds(new int[]{line.getPrimaryEntityId()})
+					.build();
+			recipients.forEach(passenger::send);
+		}
+	}
+
+	@Override
+	public void updatePosition(RenderedLine line, float yOffset, Position eyePos, Collection<User> recipients) {
+		// ArmorStand positions are managed via passenger chain, no update needed
+	}
+
+	@Override
+	public void destroy(RenderedLine line, Collection<User> recipients) {
+		DestroyEntitiesPacket packet = DestroyEntitiesPacket.builder()
+				.entityIds(line.getAllEntityIds().stream().mapToInt(Integer::intValue).toArray())
+				.build();
+		recipients.forEach(packet::send);
+	}
+
+	@Override
+	public void destroy(List<RenderedLine> lines, Collection<User> recipients) {
+		int[] ids = lines.stream()
+				.flatMap(l -> l.getAllEntityIds().stream())
+				.mapToInt(Integer::intValue)
+				.toArray();
+		DestroyEntitiesPacket packet = DestroyEntitiesPacket.builder()
+				.entityIds(ids)
+				.build();
+		recipients.forEach(packet::send);
+	}
+
+	@Override
+	public boolean supportsScaleAnimation() {
+		return false;
+	}
+
+	@Override
+	public void applyInitialScale(RenderedLine line, Bubble bubble, Collection<User> recipients) {
+		// ArmorStand doesn't support scale animation
+	}
+
+	@Override
+	public void animateSpawn(RenderedLine line, Bubble bubble, Collection<User> recipients) {
+		// ArmorStand doesn't support spawn animation
+	}
+
+	@Override
+	public void animateRemoval(RenderedLine line, Bubble bubble, Collection<User> recipients, Runnable onComplete) {
+		// ArmorStand doesn't support removal animation - just destroy immediately
+		destroy(line, recipients);
+		onComplete.run();
+	}
+
+	@Override
+	public int getPassengerAnchorId(RenderedLine line) {
+		// The next entity should attach to the armor stand (top of the chain)
+		return line.getPrimaryEntityId();
+	}
+
+	public void rechainPassenger(int vehicleId, RenderedLine line, Collection<User> recipients) {
+		ArmorStandRenderedLine asLine = (ArmorStandRenderedLine) line;
+
+		int attachTo = asLine.hasSpacer() ? asLine.getSpacerId() : asLine.getPrimaryEntityId();
+		PassengerPacket packet = PassengerPacket.builder()
+				.vehicleId(vehicleId)
+				.passengerIds(new int[]{attachTo})
+				.build();
+		recipients.forEach(packet::send);
+
+		if (asLine.hasSpacer()) {
+			PassengerPacket armorStandPacket = PassengerPacket.builder()
+					.vehicleId(asLine.getSpacerId())
+					.passengerIds(new int[]{asLine.getPrimaryEntityId()})
+					.build();
+			recipients.forEach(armorStandPacket::send);
+		}
+	}
+
+	public void attachArmorStandOnly(int vehicleId, RenderedLine renderedLine, Collection<User> recipients) {
+		ArmorStandRenderedLine line = (ArmorStandRenderedLine) renderedLine;
+
+		PassengerPacket packet = PassengerPacket.builder()
+				.vehicleId(vehicleId)
+				.passengerIds(new int[]{line.getPrimaryEntityId()})
+				.build();
+		recipients.forEach(packet::send);
+	}
+}

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/BubbleRendererFactory.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/BubbleRendererFactory.java
@@ -4,27 +4,18 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import me.whereareiam.socialismus.module.bubbler.api.model.config.BubblerSettings;
 import me.whereareiam.socialismus.module.bubbler.api.renderer.BubbleRenderer;
 import me.whereareiam.socialismus.module.bubbler.api.type.BubbleType;
 
 @Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
 public class BubbleRendererFactory {
 	private final Provider<BubblerSettings> settings;
 	private final TextDisplayRenderer textDisplayRenderer;
 	@Getter
 	private final ArmorStandRenderer armorStandRenderer;
-
-	@Inject
-	public BubbleRendererFactory(
-			Provider<BubblerSettings> settings,
-			TextDisplayRenderer textDisplayRenderer,
-			ArmorStandRenderer armorStandRenderer
-	) {
-		this.settings = settings;
-		this.textDisplayRenderer = textDisplayRenderer;
-		this.armorStandRenderer = armorStandRenderer;
-	}
 
 	public BubbleRenderer getRenderer() {
 		BubbleType type = settings.get().getBubbleType();
@@ -34,7 +25,7 @@ public class BubbleRendererFactory {
 	public BubbleRenderer getRenderer(BubbleType type) {
 		return switch (type) {
 			case TEXT_DISPLAY -> textDisplayRenderer;
-			case ARMOR_STAND, AREA_EFFECT_CLOUD -> armorStandRenderer;
+			case ARMOR_STAND -> armorStandRenderer;
 		};
 	}
 }

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/BubbleRendererFactory.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/BubbleRendererFactory.java
@@ -1,0 +1,40 @@
+package me.whereareiam.socialismus.module.bubbler.common.renderer;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import lombok.Getter;
+import me.whereareiam.socialismus.module.bubbler.api.model.config.BubblerSettings;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.BubbleRenderer;
+import me.whereareiam.socialismus.module.bubbler.api.type.BubbleType;
+
+@Singleton
+public class BubbleRendererFactory {
+	private final Provider<BubblerSettings> settings;
+	private final TextDisplayRenderer textDisplayRenderer;
+	@Getter
+	private final ArmorStandRenderer armorStandRenderer;
+
+	@Inject
+	public BubbleRendererFactory(
+			Provider<BubblerSettings> settings,
+			TextDisplayRenderer textDisplayRenderer,
+			ArmorStandRenderer armorStandRenderer
+	) {
+		this.settings = settings;
+		this.textDisplayRenderer = textDisplayRenderer;
+		this.armorStandRenderer = armorStandRenderer;
+	}
+
+	public BubbleRenderer getRenderer() {
+		BubbleType type = settings.get().getBubbleType();
+		return getRenderer(type);
+	}
+
+	public BubbleRenderer getRenderer(BubbleType type) {
+		return switch (type) {
+			case TEXT_DISPLAY -> textDisplayRenderer;
+			case ARMOR_STAND, AREA_EFFECT_CLOUD -> armorStandRenderer;
+		};
+	}
+}

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/TextDisplayRenderedLine.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/TextDisplayRenderedLine.java
@@ -1,0 +1,24 @@
+package me.whereareiam.socialismus.module.bubbler.common.renderer;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.TextDisplayPacket;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderedLine;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class TextDisplayRenderedLine implements RenderedLine {
+	private final TextDisplayPacket packet;
+
+	@Override
+	public List<Integer> getAllEntityIds() {
+		return List.of(packet.getEntityId());
+	}
+
+	@Override
+	public int getPrimaryEntityId() {
+		return packet.getEntityId();
+	}
+}

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/TextDisplayRenderer.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/TextDisplayRenderer.java
@@ -6,6 +6,7 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import me.whereareiam.socialismus.model.position.Position;
+import me.whereareiam.socialismus.module.bubbler.api.model.Vector;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
 import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleLine;
 import me.whereareiam.socialismus.module.bubbler.api.model.config.BubblerSettings;
@@ -16,7 +17,9 @@ import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.di
 import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.metadata.ScaleMetadataPacket;
 import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.metadata.TranslationMetadataPacket;
 import me.whereareiam.socialismus.module.bubbler.api.renderer.BubbleRenderer;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderStrategy;
 import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderedLine;
+import me.whereareiam.socialismus.module.bubbler.common.renderer.strategy.TextDisplayRenderStrategy;
 import me.whereareiam.socialismus.module.bubbler.common.util.PacketUtil;
 import me.whereareiam.socialismus.model.scheduler.DelayedRunnableTask;
 import me.whereareiam.socialismus.service.Scheduler;
@@ -30,11 +33,13 @@ public class TextDisplayRenderer implements BubbleRenderer {
 
 	private final Provider<BubblerSettings> settings;
 	private final Scheduler scheduler;
+	private final RenderStrategy strategy;
 
 	@Inject
 	public TextDisplayRenderer(Provider<BubblerSettings> settings, Scheduler scheduler) {
 		this.settings = settings;
 		this.scheduler = scheduler;
+		this.strategy = new TextDisplayRenderStrategy(this);
 	}
 
 	@Override
@@ -98,11 +103,6 @@ public class TextDisplayRenderer implements BubbleRenderer {
 				.entityIds(ids)
 				.build();
 		recipients.forEach(packet::send);
-	}
-
-	@Override
-	public boolean supportsScaleAnimation() {
-		return true;
 	}
 
 	@Override
@@ -188,7 +188,12 @@ public class TextDisplayRenderer implements BubbleRenderer {
 		return line.getPrimaryEntityId();
 	}
 
-	private Vector3f toVector3f(me.whereareiam.socialismus.module.bubbler.api.model.Vector v) {
+	@Override
+	public RenderStrategy getStrategy() {
+		return strategy;
+	}
+
+	private Vector3f toVector3f(Vector v) {
 		return new Vector3f(v.getX(), v.getY(), v.getZ());
 	}
 }

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/TextDisplayRenderer.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/TextDisplayRenderer.java
@@ -1,0 +1,194 @@
+package me.whereareiam.socialismus.module.bubbler.common.renderer;
+
+import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.util.Vector3f;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import me.whereareiam.socialismus.model.position.Position;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleLine;
+import me.whereareiam.socialismus.module.bubbler.api.model.config.BubblerSettings;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.PassengerPacket;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.DestroyEntitiesPacket;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.TextDisplayPacket;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.metadata.InterpolationMetadataPacket;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.metadata.ScaleMetadataPacket;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.entity.display.metadata.TranslationMetadataPacket;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.BubbleRenderer;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderedLine;
+import me.whereareiam.socialismus.module.bubbler.common.util.PacketUtil;
+import me.whereareiam.socialismus.model.scheduler.DelayedRunnableTask;
+import me.whereareiam.socialismus.service.Scheduler;
+
+import java.util.Collection;
+import java.util.List;
+
+@Singleton
+public class TextDisplayRenderer implements BubbleRenderer {
+	private static final long TICK_MS = 50L;
+
+	private final Provider<BubblerSettings> settings;
+	private final Scheduler scheduler;
+
+	@Inject
+	public TextDisplayRenderer(Provider<BubblerSettings> settings, Scheduler scheduler) {
+		this.settings = settings;
+		this.scheduler = scheduler;
+	}
+
+	@Override
+	public RenderedLine spawnLine(Bubble bubble, BubbleLine line, float yOffset, Position eyePos) {
+		Bubble.Style style = bubble.getStyle();
+		TextDisplayPacket packet = TextDisplayPacket.builder()
+				.position(PacketUtil.toVector3d(eyePos))
+				.text(line.getContent())
+				.type(style.getDisplay())
+				.backgroundColor(style.getBackground().getColor())
+				.transparency(style.getBackground().getTransparency())
+				.alignment(style.getText().getAlignment())
+				.hasShadow(style.getText().isShadow())
+				.isSeeThrough(style.isSeeThrough())
+				.translation(new Vector3f(0, yOffset, 0))
+				.build();
+
+		return new TextDisplayRenderedLine(packet);
+	}
+
+	@Override
+	public void sendSpawn(RenderedLine renderedLine, Collection<User> recipients) {
+		TextDisplayRenderedLine line = (TextDisplayRenderedLine) renderedLine;
+		recipients.forEach(r -> line.getPacket().send(r));
+	}
+
+	@Override
+	public void attachAsPassenger(int vehicleId, RenderedLine line, Collection<User> recipients) {
+		PassengerPacket packet = PassengerPacket.builder()
+				.vehicleId(vehicleId)
+				.passengerIds(new int[]{line.getPrimaryEntityId()})
+				.build();
+		recipients.forEach(packet::send);
+	}
+
+	@Override
+	public void updatePosition(RenderedLine line, float yOffset, Position eyePos, Collection<User> recipients) {
+		Vector3f translation = new Vector3f(0F, yOffset, 0F);
+		TranslationMetadataPacket packet = TranslationMetadataPacket.builder()
+				.entityId(line.getPrimaryEntityId())
+				.translation(translation)
+				.build();
+		recipients.forEach(packet::send);
+	}
+
+	@Override
+	public void destroy(RenderedLine line, Collection<User> recipients) {
+		DestroyEntitiesPacket packet = DestroyEntitiesPacket.builder()
+				.entityIds(line.getAllEntityIds().stream().mapToInt(Integer::intValue).toArray())
+				.build();
+		recipients.forEach(packet::send);
+	}
+
+	@Override
+	public void destroy(List<RenderedLine> lines, Collection<User> recipients) {
+		int[] ids = lines.stream()
+				.flatMap(l -> l.getAllEntityIds().stream())
+				.mapToInt(Integer::intValue)
+				.toArray();
+		DestroyEntitiesPacket packet = DestroyEntitiesPacket.builder()
+				.entityIds(ids)
+				.build();
+		recipients.forEach(packet::send);
+	}
+
+	@Override
+	public boolean supportsScaleAnimation() {
+		return true;
+	}
+
+	@Override
+	public void applyInitialScale(RenderedLine renderedLine, Bubble bubble, Collection<User> recipients) {
+		TextDisplayRenderedLine line = (TextDisplayRenderedLine) renderedLine;
+		float startScale = settings.get().getAnimation().getExpansion().getStartScale();
+		Vector3f scale = new Vector3f(startScale, startScale, startScale);
+
+		TextDisplayPacket scaledPacket = line.getPacket().toBuilder()
+				.scale(scale)
+				.build();
+
+		recipients.forEach(scaledPacket::send);
+	}
+
+	@Override
+	public void animateSpawn(RenderedLine line, Bubble bubble, Collection<User> recipients) {
+		long durationMs = settings.get().getAnimation().getExpansion().getDuration();
+		int ticks = Math.max(1, (int) Math.ceil(durationMs / (double) TICK_MS));
+
+		InterpolationMetadataPacket interpolation = InterpolationMetadataPacket.builder()
+				.entityId(line.getPrimaryEntityId())
+				.startDelayTicks(0)
+				.transformDurationTicks(ticks)
+				.positionRotationDurationTicks(0)
+				.build();
+		recipients.forEach(interpolation::send);
+
+		Vector3f targetScale = toVector3f(bubble.getStyle().getScale());
+		scheduler.schedule(DelayedRunnableTask.builder()
+				.module("bubbler")
+				.delay(TICK_MS)
+				.runnable(() -> {
+					ScaleMetadataPacket scale = ScaleMetadataPacket.builder()
+							.entityId(line.getPrimaryEntityId())
+							.scale(targetScale)
+							.build();
+					recipients.forEach(scale::send);
+				})
+				.build());
+	}
+
+	@Override
+	public void animateRemoval(RenderedLine line, Bubble bubble, Collection<User> recipients, Runnable onComplete) {
+		long durationMs = settings.get().getAnimation().getContraction().getDuration();
+		int ticks = Math.max(1, (int) Math.ceil(durationMs / (double) TICK_MS));
+
+		InterpolationMetadataPacket interpolation = InterpolationMetadataPacket.builder()
+				.entityId(line.getPrimaryEntityId())
+				.startDelayTicks(0)
+				.transformDurationTicks(ticks)
+				.positionRotationDurationTicks(0)
+				.build();
+		recipients.forEach(interpolation::send);
+
+		float endScale = settings.get().getAnimation().getContraction().getEndScale();
+		Vector3f scale = new Vector3f(endScale, endScale, endScale);
+
+		scheduler.schedule(DelayedRunnableTask.builder()
+				.module("bubbler")
+				.delay(TICK_MS)
+				.runnable(() -> {
+					ScaleMetadataPacket scalePacket = ScaleMetadataPacket.builder()
+							.entityId(line.getPrimaryEntityId())
+							.scale(scale)
+							.build();
+					recipients.forEach(scalePacket::send);
+				})
+				.build());
+
+		scheduler.schedule(DelayedRunnableTask.builder()
+				.module("bubbler")
+				.delay(TICK_MS + durationMs)
+				.runnable(() -> {
+					destroy(line, recipients);
+					onComplete.run();
+				})
+				.build());
+	}
+
+	@Override
+	public int getPassengerAnchorId(RenderedLine line) {
+		return line.getPrimaryEntityId();
+	}
+
+	private Vector3f toVector3f(me.whereareiam.socialismus.module.bubbler.api.model.Vector v) {
+		return new Vector3f(v.getX(), v.getY(), v.getZ());
+	}
+}

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/TextDisplayRenderer.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/TextDisplayRenderer.java
@@ -107,15 +107,18 @@ public class TextDisplayRenderer implements BubbleRenderer {
 
 	@Override
 	public void applyInitialScale(RenderedLine renderedLine, Bubble bubble, Collection<User> recipients) {
+		// This is called AFTER sendSpawn, so we send metadata to override the default scale
 		TextDisplayRenderedLine line = (TextDisplayRenderedLine) renderedLine;
 		float startScale = settings.get().getAnimation().getExpansion().getStartScale();
 		Vector3f scale = new Vector3f(startScale, startScale, startScale);
 
-		TextDisplayPacket scaledPacket = line.getPacket().toBuilder()
+		// Send scale metadata packet to set initial small scale
+		ScaleMetadataPacket scalePacket = ScaleMetadataPacket.builder()
+				.entityId(line.getPrimaryEntityId())
 				.scale(scale)
 				.build();
 
-		recipients.forEach(scaledPacket::send);
+		recipients.forEach(scalePacket::send);
 	}
 
 	@Override

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/strategy/ArmorStandRenderStrategy.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/strategy/ArmorStandRenderStrategy.java
@@ -1,0 +1,276 @@
+package me.whereareiam.socialismus.module.bubbler.common.renderer.strategy;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.protocol.player.User;
+import lombok.RequiredArgsConstructor;
+import me.whereareiam.socialismus.model.player.SocialismusPlayer;
+import me.whereareiam.socialismus.model.position.Position;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleGroup;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleLine;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.PassengerPacket;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderStrategy;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderedLine;
+import me.whereareiam.socialismus.module.bubbler.common.renderer.ArmorStandRenderedLine;
+import me.whereareiam.socialismus.module.bubbler.common.renderer.ArmorStandRenderer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Rendering strategy for ArmorStand entities.
+ * 
+ * <h2>Rendering Approach</h2>
+ * ArmorStands use passenger chaining with spacer entities for vertical offset:
+ * <ul>
+ *   <li>Each armor stand (except the first) has an invisible spacer entity</li>
+ *   <li>Spacers provide vertical offset without needing position updates</li>
+ *   <li>Entities chain together: each entity becomes a passenger of the one below it</li>
+ *   <li>Passengers appear ABOVE their vehicle, so the chain grows UPWARD from player</li>
+ * </ul>
+ * 
+ * <h2>Chain Structure</h2>
+ * <pre>
+ * Line1_ArmorStand (oldest, at top)        ← Highest above head
+ *   ↑ (passenger of)
+ * Line2_Spacer                             ← Pushes Line1 higher
+ *   ↑ (passenger of)
+ * Line2_ArmorStand
+ *   ↑ (passenger of)
+ * Line3_Spacer                             ← Pushes Line2 higher
+ *   ↑ (passenger of)
+ * Line3_ArmorStand (newest, near head)    ← Closest to head
+ *   ↑ (passenger of)
+ * Player (at bottom)                       ← Base of the chain
+ * </pre>
+ * The newest line's armor stand attaches directly to the player (no spacer first).
+ * Each line's spacer (if present) goes ABOVE its armor stand to push older lines higher.
+ * 
+ * <h2>Why This Structure?</h2>
+ * <ul>
+ *   <li>Keeps newest line close to head (no spacer lifting it up)</li>
+ *   <li>Spacers push OLD lines upward, away from head</li>
+ *   <li>Minecraft passengers appear ABOVE their vehicle, so chain grows upward</li>
+ * </ul>
+ * 
+ * <h2>Static vs Stacked Animations</h2>
+ * <ul>
+ *   <li><b>Static:</b> Entire chain built at once, spacers between each line</li>
+ *   <li><b>Stacked:</b> Chain rebuilt incrementally - new line attaches to player,
+ *       old lines rechain above it</li>
+ * </ul>
+ * 
+ * <h2>Key Methods</h2>
+ * <ul>
+ *   <li>{@code attachArmorStandOnly} - Attaches ONLY armor stand (skips spacer)</li>
+ *   <li>{@code rechainPassenger} - Attaches both spacer AND armor stand</li>
+ *   <li>{@code getPassengerAnchorId} - Returns armor stand ID (bottom of line's chain)</li>
+ *   <li>{@code getBottomAnchorId} - Returns spacer ID if present, else armor stand ID</li>
+ * </ul>
+ * 
+ * @see TextDisplayRenderStrategy for comparison with text display rendering
+ */
+@RequiredArgsConstructor
+public class ArmorStandRenderStrategy implements RenderStrategy {
+	private final ArmorStandRenderer renderer;
+
+	@Override
+	public List<RenderedLine> spawnStaticGroup(
+			Bubble bubble,
+			BubbleGroup group,
+			float headGap,
+			float spacing,
+			Position eyePos,
+			SocialismusPlayer sender,
+			Collection<User> recipients
+	) {
+		List<RenderedLine> lines = new ArrayList<>();
+		List<BubbleLine> bubbleLines = group.getLines();
+
+		int vehicleId = PacketEvents.getAPI()
+				.getPlayerManager()
+				.getUser(sender.getAudience())
+				.getEntityId();
+
+		// Create chain: Player -> Line0 -> Line1 -> Line2...
+		for (int i = 0; i < bubbleLines.size(); i++) {
+			RenderedLine line;
+			if (i == 0) {
+				line = renderer.spawnLine(bubble, bubbleLines.get(i), 0, eyePos);
+			} else {
+				line = renderer.spawnLineWithSpacer(bubbleLines.get(i), eyePos);
+			}
+
+			renderer.sendSpawn(line, recipients);
+			renderer.attachAsPassenger(vehicleId, line, recipients);
+			lines.add(line);
+
+			vehicleId = renderer.getPassengerAnchorId(line);
+		}
+
+		return lines;
+	}
+
+	@Override
+	public RenderedLine spawnStackedLine(
+			Bubble bubble,
+			BubbleLine line,
+			Position eyePos,
+			List<RenderedLine> existingLines
+	) {
+		// For stacked animations, use spacer for proper vertical spacing
+		// First line doesn't need spacer, subsequent lines do
+		if (existingLines.isEmpty()) {
+			return renderer.spawnLine(bubble, line, 0, eyePos);
+		}
+
+		return renderer.spawnLineWithSpacer(line, eyePos);
+	}
+
+	/**
+	 * Updates positions and reattaches all lines in the stack.
+	 * 
+	 * <p>This method rebuilds the ENTIRE chain from scratch. It's called when lines are removed
+	 * (during popout/overflow) to ensure the chain remains intact.
+	 * 
+	 * <p><b>Note:</b> This method is NOT called after spawning a new line in armor stand rendering,
+	 * because {@link #attachNewStackedLine} already handles the attachment incrementally.
+	 * 
+	 * <h3>Chain Rebuilding Logic:</h3>
+	 * <ol>
+	 *   <li>Attach newest line's armor stand to player (bottom of chain)</li>
+	 *   <li>Attach second-newest above newest's top anchor (spacer if present)</li>
+	 *   <li>Continue chaining older lines above the ones below them</li>
+	 * </ol>
+	 * 
+	 * <p>The chain grows upward: Player → Newest → ... → Oldest (at top)
+	 * 
+	 * @param sender the player entity
+	 * @param lines all lines in the stack (newest at end, oldest at start)
+	 * @param headGap gap from head (unused for armor stands)
+	 * @param spacing line spacing (unused for armor stands)
+	 * @param recipients packet recipients
+	 */
+	@Override
+	public void updateStackedPositions(
+			SocialismusPlayer sender,
+			List<RenderedLine> lines,
+			float headGap,
+			float spacing,
+			Collection<User> recipients
+	) {
+		// For armor stands in stacked animations, rechain them
+		// The chain grows upward: Player (bottom) → Newest → ... → Oldest (top)
+		// Only the newest line's armor stand attaches directly to player (no spacer first)
+		// This keeps the newest line near the head while older lines are pushed upward by spacers
+		if (lines.isEmpty())
+			return;
+
+		int vehicleId = PacketEvents.getAPI()
+				.getPlayerManager()
+				.getUser(sender.getAudience())
+				.getEntityId();
+
+		// Attach ONLY the armor stand of the newest line to player (keeps it near head)
+		renderer.attachArmorStandOnly(vehicleId, lines.get(lines.size() - 1), recipients);
+
+		// Chain the rest: each older line (with its spacer) attaches above the line below it
+		// Work backwards from second-newest to oldest, building upward
+		if (lines.size() > 1) {
+			// Attach the second-newest line above the newest line's anchor
+			renderer.rechainPassenger(
+					renderer.getPassengerAnchorId(lines.get(lines.size() - 1)),
+					lines.get(lines.size() - 2),
+					recipients
+			);
+
+			// Continue chaining upward for remaining lines
+			for (int i = lines.size() - 3; i >= 0; i--) {
+				RenderedLine currentLine = lines.get(i);
+				RenderedLine lineBelow = lines.get(i + 1);
+				renderer.rechainPassenger(renderer.getPassengerAnchorId(lineBelow), currentLine, recipients);
+			}
+		}
+	}
+
+	/**
+	 * Attaches a newly spawned line in a stacked animation context.
+	 * 
+	 * <p>This method is called immediately after a new line spawns, BEFORE adding it to the list.
+	 * It performs incremental attachment to maintain the chain structure without rebuilding everything.
+	 * 
+	 * <h3>Chain Building Logic:</h3>
+	 * <ol>
+	 *   <li>Attach new line's armor stand to player (keeps newest near head)</li>
+	 *   <li>If new line has spacer, attach spacer above armor stand</li>
+	 *   <li>Reattach all existing lines to chain above new line's top (spacer or armor stand)</li>
+	 * </ol>
+	 * 
+	 * <h3>Example:</h3>
+	 * <pre>
+	 * Before: Line1 (passenger of) → Player
+	 * 
+	 * After:  Line1                       ← Moved higher
+	 *           ↑ (passenger of)
+	 *         Line2_Spacer                ← Pushes Line1 up
+	 *           ↑ (passenger of)
+	 *         Line2_ArmorStand (new)      ← Near head
+	 *           ↑ (passenger of)
+	 *         Player
+	 * </pre>
+	 * 
+	 * @param sender the player entity
+	 * @param newLine the newly spawned line
+	 * @param existingLines lines that were already in the stack (need to be moved higher)
+	 * @param recipients packet recipients
+	 */
+	@Override
+	public void attachNewStackedLine(
+			SocialismusPlayer sender,
+			RenderedLine newLine,
+			List<RenderedLine> existingLines,
+			Collection<User> recipients
+	) {
+		int vehicleId = com.github.retrooper.packetevents.PacketEvents.getAPI()
+				.getPlayerManager()
+				.getUser(sender.getAudience())
+				.getEntityId();
+		
+		// Always attach the armor stand of the newest line directly to player
+		// This keeps the newest line near the head
+		renderer.attachArmorStandOnly(vehicleId, newLine, recipients);
+		
+		// If the new line has a spacer, attach it ABOVE the armor stand (as passenger)
+		// Chain grows upward: Player (bottom) → NewArmorStand → NewSpacer → OldLines (top)
+		ArmorStandRenderedLine asNewLine = (ArmorStandRenderedLine) newLine;
+		if (asNewLine.hasSpacer()) {
+			// Attach the spacer as passenger of the armor stand (appears above it)
+			PassengerPacket spacerPacket = PassengerPacket.builder()
+					.vehicleId(asNewLine.getPrimaryEntityId())
+					.passengerIds(new int[]{asNewLine.getSpacerId()})
+					.build();
+			recipients.forEach(spacerPacket::send);
+		}
+
+		// Rebuild the chain from newest to oldest existing line
+		// They should attach above the new line's "top" (its spacer if it has one, otherwise armor stand)
+		if (existingLines.isEmpty()) return;
+
+		int bottomAnchor = renderer.getBottomAnchorId(newLine);
+		// Build the chain upward from newest existing line to oldest
+		for (int i = existingLines.size() - 1; i >= 0; i--) {
+			RenderedLine currentLine = existingLines.get(i);
+
+			if (i == existingLines.size() - 1) {
+				// Newest existing line attaches above new line's top anchor
+				renderer.rechainPassenger(bottomAnchor, currentLine, recipients);
+				continue;
+			}
+
+			// Other lines attach above the line below them in the chain
+			RenderedLine lineBelow = existingLines.get(i + 1);
+			renderer.rechainPassenger(renderer.getPassengerAnchorId(lineBelow), currentLine, recipients);
+		}
+	}
+}

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/strategy/TextDisplayRenderStrategy.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/renderer/strategy/TextDisplayRenderStrategy.java
@@ -1,0 +1,140 @@
+package me.whereareiam.socialismus.module.bubbler.common.renderer.strategy;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.protocol.player.User;
+import lombok.RequiredArgsConstructor;
+import me.whereareiam.socialismus.model.player.SocialismusPlayer;
+import me.whereareiam.socialismus.model.position.Position;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.Bubble;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleGroup;
+import me.whereareiam.socialismus.module.bubbler.api.model.bubble.BubbleLine;
+import me.whereareiam.socialismus.module.bubbler.api.model.packet.type.PassengerPacket;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.BubbleRenderer;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderStrategy;
+import me.whereareiam.socialismus.module.bubbler.api.renderer.RenderedLine;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Rendering strategy for TextDisplay entities.
+ * 
+ * <h2>Rendering Approach</h2>
+ * TextDisplays use a simple batch attachment system:
+ * <ul>
+ *   <li>All text display entities spawn at calculated Y offsets</li>
+ *   <li>All entities attach directly to the player as passengers in a single batch</li>
+ *   <li>Position updates use translation metadata to move entities</li>
+ * </ul>
+ * 
+ * <h2>Chain Structure</h2>
+ * <pre>
+ * Player
+ *   ├─ Line1 (at headGap + 0 * spacing)
+ *   ├─ Line2 (at headGap + 1 * spacing)
+ *   └─ Line3 (at headGap + 2 * spacing)
+ * </pre>
+ * All lines are direct children of the player, with positions managed via metadata.
+ * 
+ * <h2>Static vs Stacked Animations</h2>
+ * <ul>
+ *   <li><b>Static:</b> All lines spawn at once and attach in a single batch</li>
+ *   <li><b>Stacked:</b> Lines spawn one by one, but batch reattachment happens after each spawn</li>
+ * </ul>
+ * 
+ * @see ArmorStandRenderStrategy for comparison with armor stand rendering
+ */
+@RequiredArgsConstructor
+public class TextDisplayRenderStrategy implements RenderStrategy {
+	private final BubbleRenderer renderer;
+
+	@Override
+	public List<RenderedLine> spawnStaticGroup(
+			Bubble bubble,
+			BubbleGroup group,
+			float headGap,
+			float spacing,
+			Position eyePos,
+			SocialismusPlayer sender,
+			Collection<User> recipients
+	) {
+		List<RenderedLine> lines = new ArrayList<>();
+		List<BubbleLine> bubbleLines = group.getLines();
+
+		// Spawn all lines
+		for (int i = 0; i < bubbleLines.size(); i++) {
+			float yOffset = headGap + i * spacing;
+			RenderedLine line = renderer.spawnLine(bubble, bubbleLines.get(i), yOffset, eyePos);
+			renderer.sendSpawn(line, recipients);
+			lines.add(line);
+		}
+
+		// Attach all as passengers in a single batch
+		batchAttachToPlayer(sender, lines, recipients);
+
+		return lines;
+	}
+
+	@Override
+	public RenderedLine spawnStackedLine(
+			Bubble bubble,
+			BubbleLine line,
+			Position eyePos,
+			List<RenderedLine> existingLines
+	) {
+		// For text displays, always use headGap positioning
+		float yOffset = bubble.getDisplay().getHeadLineGap();
+		return renderer.spawnLine(bubble, line, yOffset, eyePos);
+	}
+
+	@Override
+	public void updateStackedPositions(
+			SocialismusPlayer sender,
+			List<RenderedLine> lines,
+			float headGap,
+			float spacing,
+			Collection<User> recipients
+	) {
+		// Update positions via translation metadata
+		for (int i = lines.size() - 1, level = 0; i >= 0; i--, level++) {
+			float yOffset = headGap + level * spacing;
+			renderer.updatePosition(lines.get(i), yOffset, null, recipients);
+		}
+
+		// Reattach all as passengers
+		batchAttachToPlayer(sender, lines, recipients);
+	}
+
+	@Override
+	public void attachNewStackedLine(
+			SocialismusPlayer sender,
+			RenderedLine newLine,
+			List<RenderedLine> existingLines,
+			Collection<User> recipients
+	) {
+		// For text displays, we don't do incremental attachment
+		// Just batch attach all lines together (this will be called in updateStackedPositions)
+	}
+
+	private void batchAttachToPlayer(SocialismusPlayer sender, List<RenderedLine> lines, Collection<User> recipients) {
+		if (lines.isEmpty())
+			return;
+
+		int vehicleId = PacketEvents.getAPI()
+				.getPlayerManager()
+				.getUser(sender.getAudience())
+				.getEntityId();
+
+		int[] passengerIds = lines.stream()
+				.mapToInt(RenderedLine::getPrimaryEntityId)
+				.toArray();
+
+		PassengerPacket packet = PassengerPacket.builder()
+				.vehicleId(vehicleId)
+				.passengerIds(passengerIds)
+				.build();
+
+		recipients.forEach(packet::send);
+	}
+}

--- a/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/requirement/ActivatorRequirementValidation.java
+++ b/bubbler-common/src/main/java/me/whereareiam/socialismus/module/bubbler/common/requirement/ActivatorRequirementValidation.java
@@ -1,0 +1,60 @@
+package me.whereareiam.socialismus.module.bubbler.common.requirement;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import me.whereareiam.socialismus.logging.Logger;
+import me.whereareiam.socialismus.model.player.SocialismusPlayer;
+import me.whereareiam.socialismus.model.requirement.Requirement;
+import me.whereareiam.socialismus.model.requirement.RequirementKey;
+import me.whereareiam.socialismus.module.bubbler.api.model.requirement.ActivatorRequirement;
+import me.whereareiam.socialismus.module.bubbler.api.type.ActivatorType;
+import me.whereareiam.socialismus.module.bubbler.common.BubblerConstants;
+import me.whereareiam.socialismus.registry.base.ExtendedRegistry;
+import me.whereareiam.socialismus.service.requirement.RequirementValidation;
+
+/**
+ * Validates activator requirements for bubble messages.
+ * This is a Bubbler-specific requirement validation that checks whether
+ * a bubble was activated via chat or command.
+ */
+@Singleton
+public class ActivatorRequirementValidation implements RequirementValidation {
+	@Inject
+	public ActivatorRequirementValidation(
+			ExtendedRegistry<RequirementKey<?>, RequirementValidation> registry
+	) {
+		registry.register(BubblerConstants.Requirements.ACTIVATOR, this);
+	}
+
+	@Override
+	public boolean check(Requirement requirement, SocialismusPlayer player) {
+		if (!(requirement instanceof ActivatorRequirement activatorReq)) {
+			Logger.warn("Invalid requirement type for activator validation");
+			return false;
+		}
+
+		ActivatorType lastActivator = player.getData(BubblerConstants.DataKeys.LAST_ACTIVATOR);
+		String lastActivatorName = lastActivator != null ? lastActivator.name() : null;
+
+		Logger.debug("Checking activator requirement for player " + player.getUsername() + " [" + lastActivatorName + "]");
+
+		boolean checkResult = false;
+		switch (activatorReq.getCondition()) {
+			case EQUALS ->
+					checkResult = activatorReq.getActivators().size() == 1 && activatorReq.getActivators().get(0).equals(lastActivatorName);
+			case CONTAINS ->
+					checkResult = activatorReq.getActivators().contains(lastActivatorName);
+		}
+
+		String[] expectedValues = activatorReq.getExpected().split("\\|");
+		for (String expectedValue : expectedValues) {
+			if (String.valueOf(checkResult).equals(expectedValue)) {
+				Logger.debug("Found matching expected value: " + checkResult + " for player " + player.getUsername());
+				return true;
+			}
+		}
+
+		Logger.debug("No matching expected values found for player " + player.getUsername());
+		return false;
+	}
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # plugins
 shadow = "9.3.0"
 
-socialismus = "2.0.0-RC5"
+socialismus = "dev-9849600"
 
 # compile time processing
 lombok = "1.18.42"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a renderer/strategy pipeline for bubble rendering and adds legacy support via ArmorStand entities, with refactored animations and new activator-based requirements.
> 
> - Adds `BubbleRenderer`, `RenderStrategy`, and `RenderedLine` APIs with `TextDisplayRenderer` and `ArmorStandRenderer` implementations plus strategies
> - Refactors queued animations to use renderer/strategy (spawn, positioning, attach, destroy, and scale/translation metadata)
> - Adds legacy rendering using armor stands and area-effect cloud spacers; enhances `ArmorStandPacket` and `AreaEffectCloudPacket` and version resolution (`VersionResolver.resolveOrThrow`)
> - Introduces `ActivatorType`, `ActivatorRequirement`, constants, Configura bootstrap, and validation; sets activator on chat/command paths and stores `LAST_ACTIVATOR`
> - Updates DI wiring (injects requirement registry), config templates, and bumps Socialismus dependency; removes `AREA_EFFECT_CLOUD` from `BubbleType` in favor of renderer abstraction
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5f76d1b58961dda2c324ac5b7045bafeb5f8101. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->